### PR TITLE
Docs: align bearing after stabilization

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -12,37 +12,9 @@ until the work is resolved.
 
 ## P0 Stabilization
 
-These items come from the repo audit and the v0 design pass. See
+These open items come from the repo audit and the v0 design pass. See
+[`BEARING.md`](./BEARING.md) for the current operating map and
 [`docs/V0_DESIGN_LAWS.md`](./docs/V0_DESIGN_LAWS.md) for the product and runtime-contract rationale.
-
-### Node ESM package exports must be importable after build
-**Priority**: P0
-**Source**: Repo audit, v0 design laws
-
-`pnpm build` succeeds, but public `dist/` entrypoints for `@flyingrobots/geordi-compiler-core`,
-`@flyingrobots/geordi-schema-graphql`, and `@flyingrobots/geordi-wesley-generator` are not
-importable under Node ESM because emitted JavaScript contains extensionless or directory imports.
-Package export maps are only meaningful if consumers can import the built package.
-
-Acceptance criteria:
-- All relative runtime imports emitted to `dist/` are Node ESM compatible.
-- A post-build smoke test imports every public package entrypoint.
-- CI runs the smoke test.
-
----
-
-### Restore ESLint 10 as a real CI gate
-**Priority**: P0
-**Source**: Repo audit, CI workflow
-
-CI runs `pnpm lint`, but ESLint 10 currently fails before linting source because no flat
-`eslint.config.*` exists. Add a root flat config, or make an intentional version/config decision
-that restores `pnpm lint` as a working CI gate.
-
-Acceptance criteria:
-- `pnpm lint` passes locally.
-- The CI lint step runs source linting rather than failing on missing config.
-- The existing no-new-`Set`/`Map`-in-loops idea remains available as a follow-up rule once lint works.
 
 ---
 
@@ -62,22 +34,6 @@ Acceptance criteria:
   internal `prepare(ir)` path before rendering.
 - At least one integration test proves compiler output can be accepted by the runtime contract.
 - Legacy scene-model types are migrated, deprecated, or explicitly renamed before v0.1 release.
-
----
-
-### Implement or remove canonicalization
-**Priority**: P0
-**Source**: Repo audit, architecture docs
-
-The architecture docs and compiler options advertise canonicalization, but `compile()` does not
-execute a normalization phase. `canonicalize: true` must either have observable, tested behavior or
-be removed from the public API and docs.
-
-Acceptance criteria:
-- `normalizeCanonicalAst()` exists and is called when canonicalization is enabled, or the option is
-  removed.
-- Tests prove the selected behavior.
-- `docs/ARCHITECTURE.md` matches the implementation.
 
 ---
 
@@ -154,48 +110,38 @@ Acceptance criteria:
 
 ---
 
-### Replace placeholder tests with package contract tests
+### Expand package contract tests beyond smoke coverage
 **Priority**: P0
 **Source**: Repo audit
 
-`@flyingrobots/geordi-runtime-webgl` and `@flyingrobots/geordi-wesley-generator` currently pass
-placeholder tests. Replace them with tests that exercise public package behavior and prevent broken
-entrypoints or integration paths from passing unnoticed.
+`@flyingrobots/geordi-runtime-webgl` and `@flyingrobots/geordi-wesley-generator` now have public
+entrypoint contract tests, and the repo has a placeholder-test guard. They still need behavior tests
+that prove the runtime and generator contracts rather than only import shape.
 
 Acceptance criteria:
-- No package test suite consists only of placeholder assertions.
 - `wesley-generator` tests plan/generate on minimal SDL and asserts emitted artifacts.
 - `runtime-webgl` tests the selected IR input contract, with a canvas/context mock if needed.
-- A post-build package import smoke test is included in CI.
+- Keep the post-build package import smoke test in CI.
 
 ---
 
-### Remove tracked generated logs and stale nested lockfiles
-**Priority**: P0
-**Source**: Repo audit, repo hygiene
+## Completed Stabilization Work
 
-Tracked `packages/*/.turbo/*.log` files are rewritten by normal verification commands, and
-package-level `pnpm-lock.yaml` files under `packages/core` and `packages/runtime-webgl` are stale
-relative to the root workspace lockfile. Normal verification should not dirty the working tree.
+These P0 items were completed in the 2026-05-22 stabilization merge and are retained here as
+historical context.
 
-Acceptance criteria:
-- Tracked Turbo logs are removed from git while `.turbo/` remains ignored.
-- Stale package-level lockfiles are removed unless a nested-install workflow is explicitly documented.
-- `pnpm install --frozen-lockfile`, `pnpm build`, and `pnpm test` do not create tracked churn.
-
----
-
-### Align Turbo task outputs with command behavior
-**Priority**: P0
-**Source**: Repo audit, Turbo warnings
-
-`turbo.json` declares `coverage/**` as output for plain `test`, but package `test` scripts run
-`vitest run` without coverage. Keep coverage outputs on `test:coverage`; do not declare coverage
-outputs for plain tests unless plain tests actually emit them.
-
-Acceptance criteria:
-- `pnpm test` no longer emits Turbo "no output files found" warnings.
-- `pnpm test:coverage` still declares and caches coverage output if coverage remains supported.
+- Node ESM package exports are importable after build; `pnpm test:exports` imports every public
+  package entrypoint after `pnpm build`.
+- ESLint 10 is a real CI gate through root flat config plus package lint tasks.
+- Canonicalization is implemented through `normalizeCanonicalAst()` and wired behind
+  `canonicalize: true`.
+- Tracked generated Turbo logs and stale nested lockfiles were removed.
+- Turbo task outputs are aligned with command behavior: plain `test` has no coverage output, and
+  `test:coverage` owns coverage output.
+- Placeholder-only tests were removed, and `pnpm test:placeholders` prevents reintroduction.
+- Package name drift is guarded by `pnpm test:package-names`.
+- Documentation hygiene is guarded by `pnpm test:docs`.
+- Process scratchpad files are guarded by `pnpm test:repo-sludge`.
 
 ---
 

--- a/BEARING.md
+++ b/BEARING.md
@@ -1,0 +1,66 @@
+# Geordi Bearing
+
+**Date**: 2026-05-22
+**Branch baseline**: `main`
+**Current head when written**: `79926fb`
+
+This file is the short-term operating map. Product rationale remains in
+[`docs/V0_DESIGN_LAWS.md`](./docs/V0_DESIGN_LAWS.md); detailed work items remain in
+[`BACKLOG.md`](./BACKLOG.md).
+
+## Current Position
+
+The repo is past the first stabilization pass.
+
+Completed:
+
+- CI now runs lint, typecheck, tests, package-name checks, documentation hygiene checks,
+  placeholder-test checks, repo-sludge checks, and package export smoke tests.
+- ESLint 10 has a root flat config and type-aware package linting.
+- Public package entrypoints are smoke-tested after build.
+- The compiler uses the canonical JSON port for deterministic parse/stringify boundaries.
+- Canonicalization is implemented and wired into `compile()`.
+- Tracked generated Turbo logs and stale nested lockfiles are gone.
+- Turbo `test` outputs match command behavior.
+- Placeholder package tests have been replaced with minimal public API contract tests.
+- Dependabot is configured for grouped workspace and GitHub Actions updates.
+
+Still true:
+
+- `geordi-ir/1` is emitted by `compiler-core`, but `core` and `runtime-webgl` still expose an
+  older scene shape.
+- GraphQL directive arguments still need runtime type validation at the schema adapter boundary.
+- Known directives such as `geordi_bind` and `geordi_style` are declared but not lowered or
+  hard-rejected.
+- Adapter/compiler diagnostic transport still needs to preserve typed diagnostics and source
+  locations through `compile()`.
+- The graphics numeric profile is only partially defined. JSON is deterministic, but geometry,
+  vectors, matrices, transforms, and runtime capability declaration are not fully specified.
+
+## Immediate Moves
+
+1. Finish dependency hygiene:
+   - GitHub Actions Dependabot PR #10 was mergeable and has been merged.
+   - Conflicting npm Dependabot PR #8 should be recreated by Dependabot before any manual lockfile
+     work.
+2. Keep the next feature branch focused on diagnostics and directive validation.
+3. Do not start runtime migration before typed diagnostics and directive semantics are stable.
+
+## Recommended P0 Order
+
+1. Preserve typed diagnostics across adapter/compiler boundaries.
+2. Validate GraphQL directive argument types at runtime.
+3. Lower or explicitly reject every known Geordi directive.
+4. Expand package contract tests from entrypoint smoke to behavior coverage.
+5. Move `geordi-ir/1` into `@flyingrobots/geordi-core` as the runtime contract.
+6. Define and enforce the graphics numeric profile.
+
+## Dependency Work
+
+Open Dependabot state when this was written:
+
+- PR #10, GitHub Actions group: merged.
+- PR #8, npm/yarn group: stale/conflicting; Dependabot has been asked to recreate it.
+
+Manual lockfile conflict resolution should be avoided unless Dependabot cannot regenerate a clean
+branch.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Core compiler architecture is complete. The current implementation is focused on
 - Deterministic artifact emission
 - WebGL runtime scaffolding
 
+See [BEARING.md](BEARING.md) for the current operating map.
+
 ---
 
 ## What is GPVue?

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,186 +1,146 @@
 # Geordi Compiler Status
 
-**Date**: 2026-02-18
+**Date**: 2026-05-22
 **Version**: 0.1.0-dev
-**Milestone**: Compiler Architecture Complete ✅
+**Milestone**: First stabilization pass merged
 
-## What's Built
+See [`../BEARING.md`](../BEARING.md) for the current operating map.
 
-### ✅ Complete Packages
+## Current State
+
+The compiler architecture is in place, the repo gates are real, and the next work should focus on
+semantic correctness rather than more repository scaffolding.
+
+### Complete Packages
 
 #### `@flyingrobots/geordi-compiler-core`
-**Pure, framework-agnostic compilation engine**
 
-- ✅ Type system (Canonical AST, IR, Diagnostics, Artifacts)
-- ✅ Error taxonomy (24 error codes, stable)
-- ✅ Compile orchestrator with phases
-- ✅ Parse dispatcher (GraphQL SDL + Canonical JSON)
-- ✅ Deterministic utilities (stableStringify, hashing abstraction)
-- ✅ Golden test suite (valid + invalid fixtures)
-- ✅ Vitest configured with coverage
-- **Test status**: ✅ 86/86 passing
+Pure, framework-agnostic compilation engine.
+
+- Type system: canonical AST, IR, diagnostics, artifacts.
+- Error taxonomy with stable `GEORDI_E_*` and `GEORDI_W_*` codes.
+- Compile orchestrator with parse, canonicalize, validate, and emit phases.
+- GraphQL SDL and canonical JSON input paths.
+- Deterministic JSON port for canonical parse/stringify boundaries.
+- Deterministic IR, receipt, and TypeScript type emission.
+- Post-build public export smoke coverage.
 
 #### `@flyingrobots/geordi-schema-graphql`
-**GraphQL SDL → Canonical AST adapter**
 
-- ✅ Directive definitions (v1 spec)
-- ✅ Version validation
-- ✅ Schema validation helpers
-- ✅ Type safety (GraphQL enums, directive args)
-- ✅ Parser implementation complete
-- **Test status**: ✅ 42/42 passing
+GraphQL SDL to canonical AST adapter.
+
+- Directive definitions for v1.
+- GraphQL parser wrapper with source naming.
+- Scene and node extraction.
+- Canonical AST transform.
+- End-to-end SDL compilation coverage through compiler-core.
 
 #### `@flyingrobots/geordi-wesley-generator`
-**Wesley GeneratorPlugin adapter**
 
-- ✅ Plugin lifecycle (apiVersion, name, plan, generate)
-- ✅ Diagnostics mapping (compiler → Wesley evidence)
-- ✅ Error handling (fail gracefully on compilation errors)
-- **Status**: Scaffold complete, ready for Wesley integration
-- **Test status**: ✅ 1/1 passing
+Wesley GeneratorPlugin adapter scaffold.
+
+- Plugin lifecycle shape: `apiVersion`, `name`, `plan`, `generate`.
+- Compiler adapter injection via `graphqlToCanonicalAst`.
+- Public entrypoint contract test.
+- Still needs behavior coverage for `plan()` and `generate()`.
 
 #### `@flyingrobots/geordi-core`
-**Core types and validation**
 
-- ✅ Domain models (Node, Scene, Style)
-- ✅ Type guards and basic validation
-- **Test status**: ✅ 7/7 passing
+Core domain package.
+
+- Current domain models and guards for the older scene shape.
+- Still needs migration to own validated `geordi-ir/1` runtime contract types.
 
 #### `@flyingrobots/geordi-runtime-webgl`
-**WebGL/Canvas renderer**
 
-- ✅ Basic WebGL renderer implementation
-- ✅ Rendering utilities
-- **Test status**: ✅ 1/1 passing (placeholder)
+Canvas-backed WebGL-runtime scaffold.
 
-### ✅ Infrastructure
+- Basic renderer implementation.
+- Public entrypoint contract test.
+- Still consumes the older `GeordiScene` shape and must migrate to `geordi-ir/1`.
 
-- ✅ Monorepo structure (pnpm workspaces)
-- ✅ Turbo build pipeline
-- ✅ Changesets versioning
-- ✅ TypeScript strict mode
-- ✅ Base tsconfig shared across packages
-- ✅ Vitest test framework
-- ✅ Documentation structure
+## Infrastructure
 
-### ✅ Documentation
+- pnpm workspace.
+- Turbo build/test/lint/typecheck pipeline.
+- GitHub Actions CI.
+- Dependabot grouped updates for npm workspace dependencies and GitHub Actions.
+- Strict TypeScript and type-aware ESLint.
+- Root hygiene gates:
+  - `pnpm test:exports`
+  - `pnpm test:package-names`
+  - `pnpm test:docs`
+  - `pnpm test:placeholders`
+  - `pnpm test:repo-sludge`
 
-- ✅ [`ARCHITECTURE.md`](./ARCHITECTURE.md) - System design, seams, principles
-- ✅ [`ERROR_CODES.md`](./ERROR_CODES.md) - Complete error taxonomy
-- ✅ README updated with v0.1 status
+## Test Status
+
+Latest full local gate during the stabilization merge:
+
+| Package | Tests | Status |
+| --- | ---: | --- |
+| `@flyingrobots/geordi-compiler-core` | 71 | Green |
+| `@flyingrobots/geordi-schema-graphql` | 42 | Green |
+| `@flyingrobots/geordi-core` | 7 | Green |
+| `@flyingrobots/geordi-runtime-webgl` | 1 | Green |
+| `@flyingrobots/geordi-wesley-generator` | 1 | Green |
+| **Total package tests** | **122** | Green |
+
+Additional gates:
+
+| Gate | Status |
+| --- | --- |
+| `pnpm lint:root` | Green |
+| `pnpm exec turbo run lint --force` | Green |
+| `pnpm typecheck` | Green |
+| `pnpm test:exports` | Green |
+| `pnpm audit --prod=false` | Green |
 
 ## What's Next
 
-### Immediate (Next 7 days)
+Immediate:
 
-1. **Wesley Integration**
-   - Wire `@flyingrobots/geordi-wesley-generator` into Wesley monorepo
-   - Add Wesley peer dependency back (when ready)
-   - Test with Wesley's harness
-   - Document integration guide
+1. Keep dependency hygiene clean.
+   - GitHub Actions Dependabot update PR #10 has been merged.
+   - npm/yarn Dependabot PR #8 was stale and conflicting; Dependabot has been asked to recreate it.
+2. Preserve typed diagnostics across the schema adapter to compiler-core boundary.
+3. Validate GraphQL directive argument types at runtime.
+4. Explicitly lower or reject all known Geordi directives.
 
-2. **End-to-End Example**
-   - Convert `examples/terminal/terminal.geordi.json` to GraphQL SDL
-   - Compile with new pipeline
-   - Verify IR output matches original
-   - Add to CI as regression test
+Short term:
 
-### Short-term (Next 14 days)
+5. Expand `wesley-generator` and `runtime-webgl` tests beyond public entrypoint shape.
+6. Move versioned `geordi-ir/1` types and validation into `@flyingrobots/geordi-core`.
+7. Update `runtime-webgl` to consume the `geordi-ir/1` runtime contract.
 
-3. **Binary Packer**
-   - Design `.geordib` format spec
-   - Implement pack/unpack utilities
-   - Add tests for size/performance
+Medium term:
 
-### Medium-term (Next 30 days)
-
-4. **Source Maps**
-   - Add source location tracking
-   - Map IR nodes → SDL line/column
-   - Improve diagnostic UX
-
-5. **CLI**
-   - Create `@flyingrobots/geordi-cli` package
-   - Commands: `compile`, `validate`, `pack`
-   - Watch mode for development
-   - Integration with Wesley CLI
-
-## Test Coverage
-
-| Package | Tests | Coverage | Status |
-|---------|-------|----------|--------|
-| `@flyingrobots/geordi-compiler-core` | 86/86 ✅ | ~85% | Green |
-| `@flyingrobots/geordi-schema-graphql` | 42/42 ✅ | ~90% | Green |
-| `@flyingrobots/geordi-core` | 7/7 ✅ | ~95% | Green |
-| `@flyingrobots/geordi-runtime-webgl` | 1/1 ✅ | ~10% | Green |
-| `@flyingrobots/geordi-wesley-generator` | 1/1 ✅ | ~20% | Green |
-
-**Target**: 90%+ coverage before v0.1.0 release
+8. Define the graphics numeric profile for geometry, vectors, matrices, transforms, and runtime
+   capability requirements.
+9. Add source maps and diagnostic UX improvements.
+10. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
 
 ## Decision Log
 
 ### Architectural Decisions
 
-1. **Seam Placement**: GraphQL SDL → Canonical AST → Geordi IR
-   - **Why**: Prevents Wesley lock-in, enables multi-frontend future
-   - **Trade-off**: Extra abstraction layer vs. flexibility
+1. **Seam placement**: GraphQL SDL to canonical AST to Geordi IR.
+   - Why: prevents Wesley lock-in and enables multiple frontends.
+   - Trade-off: extra abstraction layer.
 
-2. **Error Codes**: Stable string codes (`GEORDI_E_*`)
-   - **Why**: Machine-parseable, documentation-stable, future-proof
-   - **Trade-off**: More verbose vs. easier tooling
+2. **Error codes**: stable string codes.
+   - Why: machine-parseable, documentation-stable, future-proof.
+   - Trade-off: more verbose diagnostics.
 
-3. **Hashing**: SHA-256 now, BLAKE3 later
-   - **Why**: Wesley uses SHA-256; migrate when Wesley migrates
-   - **Trade-off**: Slower hashing vs. compatibility
+3. **Hashing**: SHA-256 for current receipts.
+   - Why: standard, available, and compatible with current tooling.
+   - Trade-off: slower than future alternatives such as BLAKE3.
 
-4. **AST Version**: Option 1.5 (Geordi-shaped, not Geordi-serialized)
-   - **Why**: Fast shipping, clear escape hatch for future targets
-   - **Trade-off**: Some coupling vs. premature abstraction
+4. **Canonical JSON boundary**: all production JSON ingress/egress goes through the compiler-core
+   JSON port.
+   - Why: deterministic bytes, strict non-finite number rejection, and one place to define JSON law.
+   - Trade-off: boundary code is stricter and less convenient than native `JSON.parse/stringify`.
 
-5. **Package Placement**: Geordi monorepo for v0.1
-   - **Why**: Faster iteration, atomic refactors, easier versioning
-   - **Trade-off**: Later graduation vs. immediate separation
-
-### Implementation Decisions
-
-1. **GraphQL Parser**: Use `graphql-js` directly
-   - **Why**: Standard, no Wesley coupling, well-maintained
-   - **Alternative rejected**: Wesley's parser (vendor lock-in)
-
-2. **Test Framework**: Vitest
-   - **Why**: Consistency with existing Geordi packages, fast, ESM-native
-   - **Alternative rejected**: Jest (slower, CJS issues)
-
-3. **Monorepo Tool**: pnpm + turbo
-   - **Why**: Fast, proven, good workspace support
-   - **Alternative rejected**: npm workspaces (slower), yarn (less used)
-
-4. **Versioning**: Changesets
-   - **Why**: Disciplined, works well with pnpm, used by Wesley
-   - **Alternative rejected**: Manual versioning (error-prone)
-
-## Risks & Mitigations
-
-| Risk | Impact | Mitigation |
-|------|--------|------------|
-| Wesley API changes | High | Version pin, test against frozen Wesley snapshot |
-| GraphQL directive limits | Medium | JSON string escape hatch (v0.1), typed inputs (v0.2) |
-| Determinism guarantees break | High | Extensive property tests, golden snapshots |
-| AST evolution breaks IR | High | Version gates, migration tooling, round-trip tests |
-
-## Success Criteria (v0.1.0)
-
-- [x] Compile terminal example (GraphQL SDL → IR)
-- [x] Golden tests pass (valid + invalid fixtures)
-- [x] Determinism test passes (2x compile → identical bytes)
-- [ ] 90%+ test coverage
-- [x] Zero TypeScript errors
-- [x] Zero ESLint errors (strict config)
-- [x] Documentation complete (architecture, errors, directives)
-- [ ] Wesley integration working (if Wesley ready)
-
-## Contact
-
-**Maintainer**: Geordi Team
-**Repository**: github.com/flyingrobots/geordi
-**License**: Apache 2.0
+5. **Time outside core IR**: `geordi-ir/1` describes scene snapshots.
+   - Why: keeps v0 deterministic and avoids hidden frame scheduling semantics.
+   - Trade-off: hosts must emit new scenes for animation until a future animation profile exists.

--- a/docs/V0_DESIGN_LAWS.md
+++ b/docs/V0_DESIGN_LAWS.md
@@ -413,51 +413,77 @@ This implies source references, layout traces, and diagnostic details should be 
 
 ## P0 Stabilization Implications
 
-These are implementation backlog candidates derived from the design laws and repo audit. They should become P0 backlog items after this design is accepted.
+These implementation items were derived from the design laws and repo audit. Current backlog state
+is tracked in [`../BACKLOG.md`](../BACKLOG.md), and current operating order is tracked in
+[`../BEARING.md`](../BEARING.md).
 
 ### P0: Make Node ESM package exports importable after build
 
 Public package entrypoints must work under Node ESM after `pnpm build`. Add smoke tests that import every package through its public export path.
 
+**Status**: Completed in the first stabilization pass.
+
 ### P0: Restore ESLint 10 as a real CI gate
 
 Add a root flat ESLint config or downgrade intentionally. CI currently runs lint, so lint must either work or be removed from CI until it is real.
+
+**Status**: Completed in the first stabilization pass.
 
 ### P0: Make `geordi-ir/1` the runtime contract
 
 Move versioned IR types and validation into `@flyingrobots/geordi-core`. Update `runtime-webgl` to accept validated IR directly or expose only an internal preparation step.
 
+**Status**: Open.
+
 ### P0: Implement or remove canonicalization
 
 `canonicalize` is part of the public compiler options and docs, but the current compiler does not execute a normalization phase. Implement `normalizeCanonicalAst()` or remove the option and update docs.
+
+**Status**: Completed in the first stabilization pass.
 
 ### P0: Define the graphics numeric profile
 
 Canonical JSON alone is not enough for a graphics library. Define the v0 scalar law for geometry, vectors, matrices, transforms, and animation values. Decide which fields lower to fixed-point integers, which may remain deterministic binary64, and how the profile is declared in IR and runtime capabilities.
 
+**Status**: Open. The JSON boundary rejects non-finite numbers and canonicalizes `-0`; graphics
+math and runtime capability semantics remain open.
+
 ### P0: Validate GraphQL directive argument types at runtime
 
 Replace unsafe directive argument casts with typed extractors that emit source-located `GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE` diagnostics.
+
+**Status**: Open.
 
 ### P0: Lower or explicitly reject every known Geordi directive
 
 Known directives such as `geordi_bind` and `geordi_style` must either lower into canonical AST/IR or produce explicit unsupported-feature diagnostics. Silent drops are not allowed.
 
+**Status**: Open.
+
 ### P0: Preserve typed diagnostics across adapter/compiler boundaries
 
 Adapter failures should preserve `GEORDI_E_INPUT_INVALID_SDL`, `GEORDI_E_SCENE_MISSING`, directive errors, and source locations through `compile()`. Plain `Error` wrapping should be replaced with typed diagnostic transport.
+
+**Status**: Open.
 
 ### P0: Replace placeholder tests with package contract tests
 
 `runtime-webgl` and `wesley-generator` need tests that exercise public behavior, not placeholder assertions. Include post-build import smoke tests and at least one SDL-to-artifacts integration path.
 
+**Status**: Partially complete. Placeholder assertions are blocked by CI and package entrypoints are
+smoke-tested. Behavior tests for `runtime-webgl` and `wesley-generator` remain open.
+
 ### P0: Remove tracked generated logs and stale nested lockfiles
 
 Tracked `.turbo` logs and package-level stale lockfiles should be removed. Verification commands should not dirty the working tree.
 
+**Status**: Completed in the first stabilization pass.
+
 ### P0: Align Turbo task outputs with command behavior
 
 Plain `test` does not emit coverage, so `turbo.json` should not declare coverage output for `test`. Keep coverage outputs on `test:coverage`.
+
+**Status**: Completed in the first stabilization pass.
 
 ## Open Questions
 
@@ -471,13 +497,11 @@ These should be answered before locking the v0 IR schema:
 
 ## Recommended Next Step
 
-Add the P0 stabilization items above to `BACKLOG.md`, then implement them in dependency order:
+The first stabilization pass is merged. Continue in this order:
 
-1. Repo hygiene and Turbo outputs.
-2. ESM package importability.
-3. ESLint flat config.
-4. Public export smoke tests.
-5. Diagnostic transport and GraphQL type validation.
-6. Known directive lowering or hard rejection.
-7. Canonicalization.
-8. IR/core/runtime migration.
+1. Preserve typed diagnostics across adapter/compiler boundaries.
+2. Validate GraphQL directive argument types at runtime.
+3. Lower or explicitly reject every known Geordi directive.
+4. Expand package behavior tests beyond public entrypoint smoke.
+5. Move `geordi-ir/1` into `@flyingrobots/geordi-core` as the runtime contract.
+6. Define and enforce the graphics numeric profile.


### PR DESCRIPTION
## Summary

- add `BEARING.md` as the current operating map after the stabilization merge
- move completed stabilization work out of the open P0 backlog and leave only active P0s
- refresh `docs/STATUS.md` test counts, infrastructure state, and next moves
- annotate `docs/V0_DESIGN_LAWS.md` P0 implications with current status
- link the README status section to the bearing

## Validation

- `pnpm test:docs`
- `pnpm test:package-names`
- `pnpm test:repo-sludge`
- `git diff --check --cached`
