### PR TITLE
Fix typed diagnostics and directive validation

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -56,25 +56,6 @@ Acceptance criteria:
 
 ---
 
-### Validate GraphQL directive argument types at runtime
-**Priority**: P0
-**Source**: Repo audit, existing Post-Sprint 3 feedback
-
-`schema-graphql/extractNodes.ts` casts directive values with `as number`, `as boolean`, and
-`as string` after parsing SDL. Since this path does not perform GraphQL schema validation, wrong
-argument types can corrupt geometry and props. Replace unsafe casts with typed extractors that emit
-source-located diagnostics.
-
-Acceptance criteria:
-- Numeric, boolean, string, enum, and JSON-object directive arguments are validated at runtime.
-- Wrong directive argument types emit `GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE` with source location and
-  useful details.
-- Invalid geometry/id/parent/visibility args cause `compile().ok === false`.
-- Existing lower backlog item `schema-graphql/extractNodes - runtime type validation for directive
-  argument values` is resolved or updated.
-
----
-
 ### Lower or explicitly reject every known Geordi directive
 **Priority**: P0
 **Source**: Repo audit, fail-loud principle
@@ -87,26 +68,6 @@ Acceptance criteria:
 - `geordi_style` lowers into node style data, or returns an explicit unsupported-feature diagnostic.
 - Unknown `geordi_*` directives still produce the intended warning behavior.
 - No known Geordi directive is ignored without a diagnostic.
-
----
-
-### Preserve typed diagnostics across adapter/compiler boundaries
-**Priority**: P0
-**Source**: Repo audit, existing Post-Sprint 3 feedback
-
-`parseGraphql()` can produce typed parse errors with source locations, but adapter exceptions can be
-wrapped as `GEORDI_E_INTERNAL_INVARIANT` by `parseInputToCanonicalAst()`. Add typed diagnostic
-transport so user-facing parse and directive errors survive the `schema-graphql` to `compiler-core`
-boundary.
-
-Acceptance criteria:
-- Add a `DiagnosticsError` or equivalent typed diagnostic transport.
-- Invalid SDL through `compile()` reports `GEORDI_E_INPUT_INVALID_SDL`, not an internal invariant.
-- Missing scene through `compile()` reports `GEORDI_E_SCENE_MISSING`, without a duplicate internal
-  error.
-- Source locations survive through `compile()`.
-- Existing lower backlog items for `parseInput.ts` SDL locations and `DiagnosticsError` are resolved
-  or updated.
 
 ---
 
@@ -127,7 +88,7 @@ Acceptance criteria:
 
 ## Completed Stabilization Work
 
-These P0 items were completed in the 2026-05-22 stabilization merge and are retained here as
+These P0 items were completed in the 2026-05-22 stabilization work and are retained here as
 historical context.
 
 - Node ESM package exports are importable after build; `pnpm test:exports` imports every public
@@ -142,6 +103,11 @@ historical context.
 - Package name drift is guarded by `pnpm test:package-names`.
 - Documentation hygiene is guarded by `pnpm test:docs`.
 - Process scratchpad files are guarded by `pnpm test:repo-sludge`.
+- Typed diagnostics are preserved across the `schema-graphql` adapter to `compiler-core` boundary;
+  invalid SDL and missing scene failures no longer collapse into `GEORDI_E_INTERNAL_INVARIANT`.
+- GraphQL `@geordi_scene` and `@geordi_node` directive arguments are read through typed runtime
+  extractors; wrong literal types, non-finite numeric values, and invalid `props` JSON object
+  payloads produce `GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE`.
 
 ---
 
@@ -201,6 +167,7 @@ with an empty `props` block. This is an edge case in `TypeEmitter.emitKindInterf
 
 ### `parseInput.ts` — surface `E_INPUT_INVALID_SDL` source location to diagnostics
 **Issue**: [#7](https://github.com/flyingrobots/geordi/issues/7)
+**Status**: Resolved by the typed diagnostics transport P0 work.
 
 When `parseGraphql` throws a `ParseError` with `E_INPUT_INVALID_SDL`, `parseInput.ts` currently
 catches it and converts to a diagnostic but loses the GraphQL source location (`line`, `column`)
@@ -222,6 +189,7 @@ every field. A custom ESLint rule (or `no-restricted-syntax` selector) that flag
 
 ### `DiagnosticsError` — attach diagnostics array to thrown Errors
 **Source**: PR #1 review retrospective
+**Status**: Resolved by the typed diagnostics transport P0 work.
 
 When `adapter.ts` throws on `extractScene` failure, the thrown `Error` said "see diagnostics"
 but the diagnostics were in a local array invisible to the caller. Introduce a `DiagnosticsError`
@@ -242,10 +210,12 @@ existing `fast-check` backlog item (#4) or add a dedicated suite for `identifier
 
 ### `extractNodes` — add test: `W_UNUSED_FIELD` emitted for malformed `props` JSON
 **Source**: PR #1 review retrospective
+**Status**: Superseded. Invalid `props` JSON now emits `GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE`;
+`W_UNUSED_FIELD` remains reserved for unknown `geordi_*` directives.
 
-`extractNodes.ts` now emits `W_UNUSED_FIELD` when the `props` directive argument contains
-invalid JSON. Add a test in `extractNodes.test.ts` asserting that a field with `props: "bad json"`
-produces exactly one `W_UNUSED_FIELD` warning with the expected message.
+The earlier proposal expected malformed `props` JSON to warn as `W_UNUSED_FIELD`. That behavior
+was superseded by the fail-loud directive argument rule: malformed or non-object `props` payloads
+are argument errors, not unused fields.
 
 ---
 
@@ -305,6 +275,7 @@ the return type to `string[]` and update all callers and tests accordingly.
 
 ### `schema-graphql/extractNodes` — runtime type validation for directive argument values
 **Source**: PR #1 review retrospective (raised in rounds 2–5, deferred)
+**Status**: Resolved by the directive argument validation P0 work.
 
 `getDirectiveArgValue` returns `string | number | boolean | undefined`, but the call sites at
 lines 102–109 in `extractNodes.ts` cast results with `as number | undefined`, `as boolean | undefined`,

--- a/BEARING.md
+++ b/BEARING.md
@@ -1,8 +1,8 @@
 # Geordi Bearing
 
 **Date**: 2026-05-22
-**Branch baseline**: `main`
-**Current head when written**: `79926fb`
+**Branch baseline**: `main` at `9287157`
+**Current head when written**: `9287157`
 
 This file is the short-term operating map. Product rationale remains in
 [`docs/V0_DESIGN_LAWS.md`](./docs/V0_DESIGN_LAWS.md); detailed work items remain in
@@ -24,16 +24,16 @@ Completed:
 - Turbo `test` outputs match command behavior.
 - Placeholder package tests have been replaced with minimal public API contract tests.
 - Dependabot is configured for grouped workspace and GitHub Actions updates.
+- Typed adapter diagnostics survive through `compile()` without internal-invariant wrapping.
+- GraphQL `@geordi_scene` and `@geordi_node` directive arguments are validated at runtime before
+  values enter the canonical AST.
 
 Still true:
 
 - `geordi-ir/1` is emitted by `compiler-core`, but `core` and `runtime-webgl` still expose an
   older scene shape.
-- GraphQL directive arguments still need runtime type validation at the schema adapter boundary.
 - Known directives such as `geordi_bind` and `geordi_style` are declared but not lowered or
   hard-rejected.
-- Adapter/compiler diagnostic transport still needs to preserve typed diagnostics and source
-  locations through `compile()`.
 - The graphics numeric profile is only partially defined. JSON is deterministic, but geometry,
   vectors, matrices, transforms, and runtime capability declaration are not fully specified.
 
@@ -43,17 +43,15 @@ Still true:
    - GitHub Actions Dependabot PR #10 was mergeable and has been merged.
    - Conflicting npm Dependabot PR #8 should be recreated by Dependabot before any manual lockfile
      work.
-2. Keep the next feature branch focused on diagnostics and directive validation.
-3. Do not start runtime migration before typed diagnostics and directive semantics are stable.
+2. Next focused stabilization target: lower or explicitly reject every known Geordi directive.
+3. Do not start runtime migration before known directive semantics are fail-loud.
 
 ## Recommended P0 Order
 
-1. Preserve typed diagnostics across adapter/compiler boundaries.
-2. Validate GraphQL directive argument types at runtime.
-3. Lower or explicitly reject every known Geordi directive.
-4. Expand package contract tests from entrypoint smoke to behavior coverage.
-5. Move `geordi-ir/1` into `@flyingrobots/geordi-core` as the runtime contract.
-6. Define and enforce the graphics numeric profile.
+1. Lower or explicitly reject every known Geordi directive.
+2. Expand package contract tests from entrypoint smoke to behavior coverage.
+3. Move `geordi-ir/1` into `@flyingrobots/geordi-core` as the runtime contract.
+4. Define and enforce the graphics numeric profile.
 
 ## Dependency Work
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
 
 ### Bug Fixes
 
+- `compiler-core/parseInput`: adapter-thrown `CompilerError` diagnostics are preserved instead of being wrapped as `GEORDI_E_INTERNAL_INVARIANT`; invalid GraphQL SDL keeps its source location through `compile()`
+- `compiler-core/errors`: add `DiagnosticsError` to carry collected diagnostics across adapter boundaries without losing error codes or locations
+- `schema-graphql/adapter`: missing-scene extraction now reports `GEORDI_E_SCENE_MISSING` through `compile()` without duplicate internal-invariant diagnostics
+- `schema-graphql/directives`: replace unsafe directive argument casts with typed runtime readers for `@geordi_scene` and `@geordi_node`; wrong literal types, non-finite numeric literals, and invalid `props` JSON object payloads emit `GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE`
 - `compiler-core/compile`: `emit.binaryPack: true` now fails before any artifacts are emitted, matching the hard-failure behavior of other unsupported artifact targets
 - `compiler-core/compile`: removed wall-clock `elapsedMs` from `CompileMetadata`; compile results now remain deterministic for identical inputs
 - `emitIr`: O(n²) `shift()`+re-sort queue replaced with `qi`-pointer dequeue and batch merge of newly-ready children — O(n log n) for tree-structured graphs

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -103,22 +103,20 @@ Immediate:
 1. Keep dependency hygiene clean.
    - GitHub Actions Dependabot update PR #10 has been merged.
    - npm/yarn Dependabot PR #8 was stale and conflicting; Dependabot has been asked to recreate it.
-2. Preserve typed diagnostics across the schema adapter to compiler-core boundary.
-3. Validate GraphQL directive argument types at runtime.
-4. Explicitly lower or reject all known Geordi directives.
+2. Explicitly lower or reject all known Geordi directives.
 
 Short term:
 
-5. Expand `wesley-generator` and `runtime-webgl` tests beyond public entrypoint shape.
-6. Move versioned `geordi-ir/1` types and validation into `@flyingrobots/geordi-core`.
-7. Update `runtime-webgl` to consume the `geordi-ir/1` runtime contract.
+3. Expand `wesley-generator` and `runtime-webgl` tests beyond public entrypoint shape.
+4. Move versioned `geordi-ir/1` types and validation into `@flyingrobots/geordi-core`.
+5. Update `runtime-webgl` to consume the `geordi-ir/1` runtime contract.
 
 Medium term:
 
-8. Define the graphics numeric profile for geometry, vectors, matrices, transforms, and runtime
+6. Define the graphics numeric profile for geometry, vectors, matrices, transforms, and runtime
    capability requirements.
-9. Add source maps and diagnostic UX improvements.
-10. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
+7. Add source maps and diagnostic UX improvements.
+8. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
 
 ## Decision Log
 

--- a/docs/V0_DESIGN_LAWS.md
+++ b/docs/V0_DESIGN_LAWS.md
@@ -452,7 +452,7 @@ math and runtime capability semantics remain open.
 
 Replace unsafe directive argument casts with typed extractors that emit source-located `GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE` diagnostics.
 
-**Status**: Open.
+**Status**: Completed. `@geordi_scene` and `@geordi_node` arguments now cross the schema boundary through typed runtime readers; wrong literal types, non-finite numeric values, and invalid `props` JSON object payloads fail with source-located diagnostics.
 
 ### P0: Lower or explicitly reject every known Geordi directive
 
@@ -464,7 +464,7 @@ Known directives such as `geordi_bind` and `geordi_style` must either lower into
 
 Adapter failures should preserve `GEORDI_E_INPUT_INVALID_SDL`, `GEORDI_E_SCENE_MISSING`, directive errors, and source locations through `compile()`. Plain `Error` wrapping should be replaced with typed diagnostic transport.
 
-**Status**: Open.
+**Status**: Completed. Adapter-thrown compiler errors are preserved, and `DiagnosticsError` carries already-collected diagnostics across the `schema-graphql` to `compiler-core` boundary.
 
 ### P0: Replace placeholder tests with package contract tests
 

--- a/packages/compiler-core/src/compile/parseInput.ts
+++ b/packages/compiler-core/src/compile/parseInput.ts
@@ -1,5 +1,12 @@
 import type { CanonicalSceneAst, CompilerInput, Diagnostic, JsonObject, JsonValue } from '../types/index.js';
-import { ParseError, GeordiErrorCode, normalizeCompilerErrorCause, type ThrownValue } from '../errors/index.js';
+import {
+  CompilerError,
+  DiagnosticsError,
+  ParseError,
+  GeordiErrorCode,
+  normalizeCompilerErrorCause,
+  type ThrownValue,
+} from '../errors/index.js';
 import { JsonParseError, parseJsonValue } from '../ports/json.js';
 
 /**
@@ -92,6 +99,16 @@ async function parseGraphqlSdl(
     const hasErrors = structural.some((d) => d.severity === 'error');
     return hasErrors ? undefined : ast;
   } catch (cause) {
+    if (cause instanceof DiagnosticsError) {
+      appendUniqueDiagnostics(diagnostics, cause.diagnostics);
+      return undefined;
+    }
+
+    if (cause instanceof CompilerError) {
+      diagnostics.push(cause.toDiagnostic());
+      return undefined;
+    }
+
     diagnostics.push(
       new ParseError(
         GeordiErrorCode.E_INTERNAL_INVARIANT,
@@ -103,6 +120,17 @@ async function parseGraphqlSdl(
       ).toDiagnostic(),
     );
     return undefined;
+  }
+}
+
+function appendUniqueDiagnostics(
+  target: Diagnostic[],
+  diagnostics: readonly Diagnostic[],
+): void {
+  for (const diagnostic of diagnostics) {
+    if (!target.includes(diagnostic)) {
+      target.push(diagnostic);
+    }
   }
 }
 

--- a/packages/compiler-core/src/errors/DiagnosticsError.ts
+++ b/packages/compiler-core/src/errors/DiagnosticsError.ts
@@ -1,0 +1,11 @@
+import type { Diagnostic } from '../types/index.js';
+
+export class DiagnosticsError extends Error {
+  public readonly diagnostics: readonly Diagnostic[];
+
+  constructor(diagnostics: readonly Diagnostic[], message = 'Compilation produced diagnostics') {
+    super(message);
+    this.name = new.target.name;
+    this.diagnostics = [...diagnostics];
+  }
+}

--- a/packages/compiler-core/src/errors/index.ts
+++ b/packages/compiler-core/src/errors/index.ts
@@ -1,5 +1,6 @@
 export * from './codes.js';
 export * from './CompilerError.js';
+export * from './DiagnosticsError.js';
 export * from './ParseError.js';
 export * from './ValidationError.js';
 export * from './EmitError.js';

--- a/packages/compiler-core/test/parseInput.test.ts
+++ b/packages/compiler-core/test/parseInput.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { parseInputToCanonicalAst } from '../src/compile/parseInput';
-import { GeordiErrorCode } from '../src/errors';
+import { GeordiErrorCode, ParseError } from '../src/errors';
 import { stringifyCanonicalJson } from '../src/ports/json';
 import type { CompilerInput, Diagnostic, JsonValue } from '../src/types';
 
@@ -136,5 +136,30 @@ describe('parseInputToCanonicalAst (table-driven)', () => {
     const withHint = errorDiags.find((d) => d.hint);
     expect(withHint).toBeDefined();
     expect(withHint?.hint).toContain('schema-graphql');
+  });
+
+  it('graphql-sdl preserves typed diagnostics thrown by adapter', async () => {
+    const diagnostics: Diagnostic[] = [];
+    const result = await parseInputToCanonicalAst(
+      {
+        format: 'graphql-sdl',
+        source: 'type Broken {',
+        filename: 'broken.graphql',
+      },
+      diagnostics,
+      {
+        graphqlToCanonicalAst: () => {
+          throw new ParseError(GeordiErrorCode.E_INPUT_INVALID_SDL, 'adapter typed parse error', {
+            location: { file: 'broken.graphql', line: 1, column: 13 },
+          });
+        },
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].code).toBe(GeordiErrorCode.E_INPUT_INVALID_SDL);
+    expect(diagnostics[0].location).toEqual({ file: 'broken.graphql', line: 1, column: 13 });
+    expect(diagnostics.map((d) => d.code)).not.toContain(GeordiErrorCode.E_INTERNAL_INVARIANT);
   });
 });

--- a/packages/schema-graphql/src/adapter.ts
+++ b/packages/schema-graphql/src/adapter.ts
@@ -1,6 +1,6 @@
 import type { CanonicalSceneAst, Diagnostic } from '@flyingrobots/geordi-compiler-core';
 import type { GraphqlToCanonicalAst } from '@flyingrobots/geordi-compiler-core';
-import { GeordiErrorCode, ParseError } from '@flyingrobots/geordi-compiler-core';
+import { DiagnosticsError, GeordiErrorCode, ParseError } from '@flyingrobots/geordi-compiler-core';
 import { parseGraphql } from './parse/parseGraphql.js';
 import { extractScene } from './parse/extractScene.js';
 import { extractNodes } from './parse/extractNodes.js';
@@ -8,12 +8,6 @@ import { toCanonicalAst } from './transform/toCanonicalAst.js';
 
 // Re-export the type so callers can import it from this package
 export type { GraphqlToCanonicalAst };
-
-class GraphqlSceneExtractionError extends ParseError {
-  constructor(message: string) {
-    super(GeordiErrorCode.E_SCENE_MISSING, message);
-  }
-}
 
 /**
  * Converts a GraphQL SDL string into a CanonicalSceneAst.
@@ -38,7 +32,11 @@ export const graphqlToCanonicalAst: GraphqlToCanonicalAst = (args: {
       diagnostics.length > 0
         ? diagnostics[diagnostics.length - 1].message
         : 'Scene extraction failed';
-    throw new GraphqlSceneExtractionError(reason);
+    const sceneDiagnostics =
+      diagnostics.length > 0
+        ? diagnostics
+        : [new ParseError(GeordiErrorCode.E_SCENE_MISSING, reason).toDiagnostic()];
+    throw new DiagnosticsError(sceneDiagnostics, reason);
   }
 
   // Step 3: Extract nodes

--- a/packages/schema-graphql/src/parse/directiveArgs.ts
+++ b/packages/schema-graphql/src/parse/directiveArgs.ts
@@ -1,0 +1,260 @@
+import { Kind, type ArgumentNode, type DirectiveNode, type ValueNode } from 'graphql';
+import { GeordiErrorCode, ParseError } from '@flyingrobots/geordi-compiler-core';
+import type { Diagnostic, JsonObject } from '@flyingrobots/geordi-compiler-core';
+import { nodeSourceRef } from './sourceRef.js';
+
+export interface DirectiveArgReaderContext {
+  directive: DirectiveNode;
+  directiveName: string;
+  diagnostics: Diagnostic[];
+  filename?: string;
+  owner: string;
+}
+
+interface DirectiveArgValidationContext extends DirectiveArgReaderContext {
+  argName: string;
+}
+
+export function readRequiredStringArg(
+  context: DirectiveArgReaderContext,
+  argName: string,
+): string | undefined {
+  const arg = findArg(context, argName);
+  if (!arg) {
+    pushMissingArg(context, argName);
+    return undefined;
+  }
+
+  if (arg.value.kind === Kind.STRING) {
+    return arg.value.value;
+  }
+
+  pushInvalidType({ ...context, argName }, 'string', arg.value);
+  return undefined;
+}
+
+export function readOptionalStringArg(
+  context: DirectiveArgReaderContext,
+  argName: string,
+): string | undefined {
+  return readStringArg(context, argName);
+}
+
+export function readRequiredIntArg(
+  context: DirectiveArgReaderContext,
+  argName: string,
+): number | undefined {
+  const arg = findArg(context, argName);
+  if (!arg) {
+    pushMissingArg(context, argName);
+    return undefined;
+  }
+
+  if (arg.value.kind === Kind.INT) {
+    const value = parseSafeInteger(arg.value.value);
+    if (value !== undefined) {
+      return value;
+    }
+
+    pushInvalidType({ ...context, argName }, 'safe integer', arg.value, 'unsafe integer');
+    return undefined;
+  }
+
+  pushInvalidType({ ...context, argName }, 'integer', arg.value);
+  return undefined;
+}
+
+export function readOptionalIntArg(
+  context: DirectiveArgReaderContext,
+  argName: string,
+): number | undefined {
+  return readIntArg(context, argName);
+}
+
+export function readOptionalFloatArg(
+  context: DirectiveArgReaderContext,
+  argName: string,
+): number | undefined {
+  const arg = findArg(context, argName);
+  if (!arg) {
+    return undefined;
+  }
+
+  if (arg.value.kind === Kind.INT || arg.value.kind === Kind.FLOAT) {
+    const value = parseFiniteNumber(arg.value.value);
+    if (value !== undefined) {
+      return value;
+    }
+
+    pushInvalidType({ ...context, argName }, 'finite number', arg.value, 'non-finite number');
+    return undefined;
+  }
+
+  pushInvalidType({ ...context, argName }, 'number', arg.value);
+  return undefined;
+}
+
+export function readOptionalBooleanArg(
+  context: DirectiveArgReaderContext,
+  argName: string,
+): boolean | undefined {
+  const arg = findArg(context, argName);
+  if (!arg) {
+    return undefined;
+  }
+
+  if (arg.value.kind === Kind.BOOLEAN) {
+    return arg.value.value;
+  }
+
+  pushInvalidType({ ...context, argName }, 'boolean', arg.value);
+  return undefined;
+}
+
+export function readRequiredEnumArg(
+  context: DirectiveArgReaderContext,
+  argName: string,
+): string | undefined {
+  const arg = findArg(context, argName);
+  if (!arg) {
+    pushMissingArg(context, argName);
+    return undefined;
+  }
+
+  if (arg.value.kind === Kind.ENUM) {
+    return arg.value.value;
+  }
+
+  pushInvalidType({ ...context, argName }, 'enum', arg.value);
+  return undefined;
+}
+
+function readStringArg(
+  context: DirectiveArgReaderContext,
+  argName: string,
+): string | undefined {
+  const arg = findArg(context, argName);
+  if (!arg) {
+    return undefined;
+  }
+
+  if (arg.value.kind === Kind.STRING) {
+    return arg.value.value;
+  }
+
+  pushInvalidType({ ...context, argName }, 'string', arg.value);
+  return undefined;
+}
+
+function readIntArg(
+  context: DirectiveArgReaderContext,
+  argName: string,
+): number | undefined {
+  const arg = findArg(context, argName);
+  if (!arg) {
+    return undefined;
+  }
+
+  if (arg.value.kind === Kind.INT) {
+    const value = parseSafeInteger(arg.value.value);
+    if (value !== undefined) {
+      return value;
+    }
+
+    pushInvalidType({ ...context, argName }, 'safe integer', arg.value, 'unsafe integer');
+    return undefined;
+  }
+
+  pushInvalidType({ ...context, argName }, 'integer', arg.value);
+  return undefined;
+}
+
+function findArg(
+  context: DirectiveArgReaderContext,
+  argName: string,
+): ArgumentNode | undefined {
+  return context.directive.arguments?.find((candidate) => candidate.name.value === argName);
+}
+
+function pushMissingArg(context: DirectiveArgReaderContext, argName: string): void {
+  context.diagnostics.push(
+    new ParseError(
+      GeordiErrorCode.E_DIRECTIVE_ARG_MISSING,
+      `${context.owner} requires @${context.directiveName} argument ${argName}`,
+      {
+        location: nodeSourceRef(context.directive, context.filename),
+        details: directiveArgDetails(context.directiveName, argName, 'present', 'missing'),
+      },
+    ).toDiagnostic(),
+  );
+}
+
+function pushInvalidType(
+  context: DirectiveArgValidationContext,
+  expected: string,
+  value: ValueNode,
+  actual = valueKindLabel(value),
+): void {
+  context.diagnostics.push(
+    new ParseError(
+      GeordiErrorCode.E_DIRECTIVE_ARG_INVALID_TYPE,
+      `${context.owner} @${context.directiveName} argument ${context.argName} must be ${expected}`,
+      {
+        location: nodeSourceRef(value, context.filename),
+        details: directiveArgDetails(
+          context.directiveName,
+          context.argName,
+          expected,
+          actual,
+        ),
+      },
+    ).toDiagnostic(),
+  );
+}
+
+function parseFiniteNumber(raw: string): number | undefined {
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function parseSafeInteger(raw: string): number | undefined {
+  const value = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(value) ? value : undefined;
+}
+
+function directiveArgDetails(
+  directiveName: string,
+  argName: string,
+  expected: string,
+  actual: string,
+): JsonObject {
+  return {
+    directive: directiveName,
+    argument: argName,
+    expected,
+    actual,
+  };
+}
+
+function valueKindLabel(value: ValueNode): string {
+  switch (value.kind) {
+    case Kind.STRING:
+      return 'string';
+    case Kind.INT:
+      return 'integer';
+    case Kind.FLOAT:
+      return 'float';
+    case Kind.BOOLEAN:
+      return 'boolean';
+    case Kind.ENUM:
+      return 'enum';
+    case Kind.LIST:
+      return 'list';
+    case Kind.OBJECT:
+      return 'object';
+    case Kind.NULL:
+      return 'null';
+    case Kind.VARIABLE:
+      return 'variable';
+  }
+}

--- a/packages/schema-graphql/src/parse/extractNodes.ts
+++ b/packages/schema-graphql/src/parse/extractNodes.ts
@@ -1,10 +1,14 @@
-import {
-  type DirectiveNode,
-  Kind,
-} from 'graphql';
 import { ParseError, GeordiErrorCode, parseJsonValue } from '@flyingrobots/geordi-compiler-core';
 import type { Diagnostic, JsonObject, JsonValue, NodeKind, SourceRef } from '@flyingrobots/geordi-compiler-core';
 import { isGeordiNodeKind } from '../directives/v1.js';
+import {
+  readOptionalBooleanArg,
+  readOptionalFloatArg,
+  readOptionalIntArg,
+  readOptionalStringArg,
+  readRequiredEnumArg,
+  type DirectiveArgReaderContext,
+} from './directiveArgs.js';
 import type { ExtractedScene } from './extractScene.js';
 import { nodeSourceRef } from './sourceRef.js';
 
@@ -22,28 +26,6 @@ export interface ExtractedNode {
   props?: JsonObject;
   sourceRef: SourceRef;
   fieldOrder: number;
-}
-
-function getDirectiveArgValue(
-  directive: DirectiveNode,
-  argName: string,
-): string | number | boolean | undefined {
-  const arg = directive.arguments?.find((a) => a.name.value === argName);
-  if (!arg) return undefined;
-  switch (arg.value.kind) {
-    case Kind.STRING:
-      return arg.value.value;
-    case Kind.INT:
-      return parseInt(arg.value.value, 10);
-    case Kind.FLOAT:
-      return parseFloat(arg.value.value);
-    case Kind.BOOLEAN:
-      return arg.value.value;
-    case Kind.ENUM:
-      return arg.value.value;
-    default:
-      return undefined;
-  }
 }
 
 const KNOWN_GEORDI_DIRS = new Set(['geordi_scene', 'geordi_node', 'geordi_bind', 'geordi_style']);
@@ -82,13 +64,25 @@ export function extractNodes(
     const nodeDir = field.directives?.find((d) => d.name.value === 'geordi_node');
     if (!nodeDir) continue;
 
+    const argContext: DirectiveArgReaderContext = {
+      directive: nodeDir,
+      directiveName: 'geordi_node',
+      diagnostics,
+      filename,
+      owner: `field "${field.name.value}"`,
+    };
+
     // Extract kind (required enum arg)
-    const kindRaw = getDirectiveArgValue(nodeDir, 'kind');
+    const kindRaw = readRequiredEnumArg(argContext, 'kind');
+    if (kindRaw === undefined) {
+      continue;
+    }
+
     if (!isGeordiNodeKind(kindRaw)) {
       diagnostics.push(
         new ParseError(
           GeordiErrorCode.E_NODE_KIND_INVALID,
-          `Invalid or missing node kind "${String(kindRaw ?? '')}" on field "${field.name.value}". Valid kinds: Rect, Text, Image, Group, Line, Ellipse, Path`,
+          `Invalid node kind "${kindRaw}" on field "${field.name.value}". Valid kinds: Rect, Text, Image, Group, Line, Ellipse, Path`,
           { location: sourceRef },
         ).toDiagnostic(),
       );
@@ -98,38 +92,28 @@ export function extractNodes(
     const kind = kindRaw;
 
     // Extract geometry
-    const x = (getDirectiveArgValue(nodeDir, 'x') as number | undefined) ?? 0;
-    const y = (getDirectiveArgValue(nodeDir, 'y') as number | undefined) ?? 0;
-    const width = getDirectiveArgValue(nodeDir, 'width') as number | undefined;
-    const height = getDirectiveArgValue(nodeDir, 'height') as number | undefined;
-    const zIndex = getDirectiveArgValue(nodeDir, 'zIndex') as number | undefined;
-    const visible = getDirectiveArgValue(nodeDir, 'visible') as boolean | undefined;
-    const parent = getDirectiveArgValue(nodeDir, 'parent') as string | undefined;
-    const id = getDirectiveArgValue(nodeDir, 'id') as string | undefined;
+    const x = readOptionalFloatArg(argContext, 'x') ?? 0;
+    const y = readOptionalFloatArg(argContext, 'y') ?? 0;
+    const width = readOptionalFloatArg(argContext, 'width');
+    const height = readOptionalFloatArg(argContext, 'height');
+    const zIndex = readOptionalIntArg(argContext, 'zIndex');
+    const visible = readOptionalBooleanArg(argContext, 'visible');
+    const parent = readOptionalStringArg(argContext, 'parent');
+    const id = readOptionalStringArg(argContext, 'id');
 
     // Parse props JSON arg if present
     let props: JsonObject | undefined;
-    const propsRaw = getDirectiveArgValue(nodeDir, 'props') as string | undefined;
-    if (propsRaw) {
+    const propsRaw = readOptionalStringArg(argContext, 'props');
+    if (propsRaw !== undefined) {
       try {
         const parsed = parseJsonValue(propsRaw);
         if (isJsonObject(parsed)) {
           props = parsed;
         } else {
-          diagnostics.push({
-            code: GeordiErrorCode.E_DIRECTIVE_ARG_INVALID_TYPE,
-            severity: 'warning',
-            message: `Field "${field.name.value}" props argument must be a JSON object — ignoring`,
-            location: sourceRef,
-          });
+          pushPropsInvalidType(diagnostics, field.name.value, sourceRef);
         }
       } catch {
-        diagnostics.push({
-          code: GeordiErrorCode.E_DIRECTIVE_ARG_INVALID_TYPE,
-          severity: 'warning',
-          message: `Field "${field.name.value}" has an invalid props JSON value — ignoring props argument`,
-          location: sourceRef,
-        });
+        pushPropsInvalidType(diagnostics, field.name.value, sourceRef);
       }
     }
 
@@ -155,4 +139,25 @@ export function extractNodes(
 
 function isJsonObject(value: JsonValue): value is JsonObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function pushPropsInvalidType(
+  diagnostics: Diagnostic[],
+  fieldName: string,
+  sourceRef: SourceRef,
+): void {
+  diagnostics.push(
+    new ParseError(
+      GeordiErrorCode.E_DIRECTIVE_ARG_INVALID_TYPE,
+      `Field "${fieldName}" @geordi_node argument props must be a JSON object string`,
+      {
+        location: sourceRef,
+        details: {
+          directive: 'geordi_node',
+          argument: 'props',
+          expected: 'json-object-string',
+        },
+      },
+    ).toDiagnostic(),
+  );
 }

--- a/packages/schema-graphql/src/parse/extractScene.ts
+++ b/packages/schema-graphql/src/parse/extractScene.ts
@@ -1,13 +1,13 @@
-import {
-  type DocumentNode,
-  type ObjectTypeDefinitionNode,
-  type DirectiveNode,
-  type ArgumentNode,
-  Kind,
-} from 'graphql';
+import { type DocumentNode, type ObjectTypeDefinitionNode, Kind } from 'graphql';
 import { ParseError, GeordiErrorCode } from '@flyingrobots/geordi-compiler-core';
 import type { Diagnostic, SourceRef } from '@flyingrobots/geordi-compiler-core';
 import { validateGeordiDirectiveVersion } from '../directives/v1.js';
+import {
+  readOptionalStringArg,
+  readRequiredIntArg,
+  readRequiredStringArg,
+  type DirectiveArgReaderContext,
+} from './directiveArgs.js';
 import { nodeSourceRef } from './sourceRef.js';
 
 export interface ExtractedScene {
@@ -19,27 +19,6 @@ export interface ExtractedScene {
   background?: string;
   sourceRef: SourceRef;
   typeNode: ObjectTypeDefinitionNode;
-}
-
-function getArgValue(
-  directive: DirectiveNode,
-  argName: string,
-): ArgumentNode | undefined {
-  return directive.arguments?.find((a) => a.name.value === argName);
-}
-
-function getStringArg(directive: DirectiveNode, argName: string): string | undefined {
-  const arg = getArgValue(directive, argName);
-  if (!arg) return undefined;
-  if (arg.value.kind === Kind.STRING) return arg.value.value;
-  return undefined;
-}
-
-function getIntArg(directive: DirectiveNode, argName: string): number | undefined {
-  const arg = getArgValue(directive, argName);
-  if (!arg) return undefined;
-  if (arg.value.kind === Kind.INT) return parseInt(arg.value.value, 10);
-  return undefined;
 }
 
 /**
@@ -99,15 +78,15 @@ export function extractScene(
   }
 
   // Validate version
-  const v = getStringArg(sceneDir, 'v');
-  if (!v) {
-    diagnostics.push(
-      new ParseError(
-        GeordiErrorCode.E_DIRECTIVE_ARG_MISSING,
-        `@geordi_scene requires argument v: "1"`,
-        { location: sourceRef },
-      ).toDiagnostic(),
-    );
+  const argContext: DirectiveArgReaderContext = {
+    directive: sceneDir,
+    directiveName: 'geordi_scene',
+    diagnostics,
+    filename,
+    owner: `type "${typeNode.name.value}"`,
+  };
+  const v = readRequiredStringArg(argContext, 'v');
+  if (v === undefined) {
     return undefined;
   }
 
@@ -124,33 +103,15 @@ export function extractScene(
   }
 
   // Validate required numeric args
-  const width = getIntArg(sceneDir, 'width');
-  const height = getIntArg(sceneDir, 'height');
+  const width = readRequiredIntArg(argContext, 'width');
+  const height = readRequiredIntArg(argContext, 'height');
 
-  if (width === undefined) {
-    diagnostics.push(
-      new ParseError(
-        GeordiErrorCode.E_DIRECTIVE_ARG_MISSING,
-        `@geordi_scene requires argument: width`,
-        { location: sourceRef },
-      ).toDiagnostic(),
-    );
+  if (width === undefined || height === undefined) {
     return undefined;
   }
 
-  if (height === undefined) {
-    diagnostics.push(
-      new ParseError(
-        GeordiErrorCode.E_DIRECTIVE_ARG_MISSING,
-        `@geordi_scene requires argument: height`,
-        { location: sourceRef },
-      ).toDiagnostic(),
-    );
-    return undefined;
-  }
-
-  const name = getStringArg(sceneDir, 'name');
-  const background = getStringArg(sceneDir, 'background');
+  const name = readOptionalStringArg(argContext, 'name');
+  const background = readOptionalStringArg(argContext, 'background');
 
   return {
     typeName: typeNode.name.value,

--- a/packages/schema-graphql/test/e2e.terminal.test.ts
+++ b/packages/schema-graphql/test/e2e.terminal.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
-import { compile, parseJsonValue } from '@flyingrobots/geordi-compiler-core';
+import { compile, GeordiErrorCode, parseJsonValue } from '@flyingrobots/geordi-compiler-core';
 import { graphqlToCanonicalAst } from '../src/index';
 import type { CompilerInput, CompileResult, GeordiIrV1, ParseInputDeps } from '@flyingrobots/geordi-compiler-core';
 
@@ -135,5 +135,47 @@ describe('e2e: Terminal SDL fixture', () => {
     const ir = parseIr(result);
     const zIndices = ir.nodes.map((n) => n.zIndex ?? 0);
     expect(zIndices).toEqual([...zIndices].sort((a: number, b: number) => a - b));
+  });
+
+  it('surfaces invalid SDL as GEORDI_E_INPUT_INVALID_SDL', async () => {
+    const result = await compile(makeInput('type Broken {', 'broken.graphql'), DEPS);
+
+    expect(result.ok).toBe(false);
+    const invalidSdl = result.diagnostics.find(
+      (d) => d.code === GeordiErrorCode.E_INPUT_INVALID_SDL,
+    );
+    expect(invalidSdl).toBeDefined();
+    expect(invalidSdl?.location?.file).toBe('broken.graphql');
+    expect(invalidSdl?.location?.line).toBeGreaterThanOrEqual(1);
+    expect(invalidSdl?.location?.column).toBeGreaterThanOrEqual(1);
+    expect(result.diagnostics.map((d) => d.code)).not.toContain(
+      GeordiErrorCode.E_INTERNAL_INVARIANT,
+    );
+  });
+
+  it('surfaces missing scene as GEORDI_E_SCENE_MISSING without internal wrapping', async () => {
+    const result = await compile(makeInput('type Query { _: String }', 'missing-scene.graphql'), DEPS);
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics.map((d) => d.code)).toEqual([GeordiErrorCode.E_SCENE_MISSING]);
+  });
+
+  it('fails on invalid directive argument literal types', async () => {
+    const result = await compile(
+      makeInput(
+        `
+        type S @geordi_scene(v: "1", width: 100, height: 100) {
+          n: String @geordi_node(kind: Rect, x: "left")
+        }
+      `,
+        'bad-directive.graphql',
+      ),
+      DEPS,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics.map((d) => d.code)).toContain(
+      GeordiErrorCode.E_DIRECTIVE_ARG_INVALID_TYPE,
+    );
   });
 });

--- a/packages/schema-graphql/test/extractNodes.test.ts
+++ b/packages/schema-graphql/test/extractNodes.test.ts
@@ -127,6 +127,57 @@ describe('extractNodes (table-driven)', () => {
     expect(nodes[0].props).toEqual({ fill: '#ff0000' });
   });
 
+  it('wrong node argument type → GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE', () => {
+    const diag: Diagnostic[] = [];
+    parseAndExtract(
+      `
+      type S @geordi_scene(v: "1", width: 100, height: 100) {
+        n: String @geordi_node(kind: Rect, x: "left", visible: "yes")
+      }
+    `,
+      diag,
+    );
+
+    const errors = diag.filter((d) => d.severity === 'error');
+    expect(errors.map((d) => d.code)).toEqual([
+      GeordiErrorCode.E_DIRECTIVE_ARG_INVALID_TYPE,
+      GeordiErrorCode.E_DIRECTIVE_ARG_INVALID_TYPE,
+    ]);
+    expect(errors.map((d) => d.message).join('\n')).toContain('x');
+    expect(errors.map((d) => d.message).join('\n')).toContain('visible');
+  });
+
+  it('non-finite numeric node argument → GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE', () => {
+    const diag: Diagnostic[] = [];
+    parseAndExtract(
+      `
+      type S @geordi_scene(v: "1", width: 100, height: 100) {
+        n: String @geordi_node(kind: Rect, x: 1e999)
+      }
+    `,
+      diag,
+    );
+
+    const errors = diag.filter((d) => d.severity === 'error');
+    expect(errors.map((d) => d.code)).toContain(GeordiErrorCode.E_DIRECTIVE_ARG_INVALID_TYPE);
+    expect(errors.map((d) => d.details?.actual)).toContain('non-finite number');
+  });
+
+  it('invalid props JSON → GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE error', () => {
+    const diag: Diagnostic[] = [];
+    parseAndExtract(
+      `
+      type S @geordi_scene(v: "1", width: 100, height: 100) {
+        n: String @geordi_node(kind: Rect, props: "[1,2,3]")
+      }
+    `,
+      diag,
+    );
+
+    const errors = diag.filter((d) => d.severity === 'error');
+    expect(errors.map((d) => d.code)).toContain(GeordiErrorCode.E_DIRECTIVE_ARG_INVALID_TYPE);
+  });
+
   it('preserves field order as fieldOrder property', () => {
     const diag: Diagnostic[] = [];
     const { nodes } = parseAndExtract(

--- a/packages/schema-graphql/test/extractScene.test.ts
+++ b/packages/schema-graphql/test/extractScene.test.ts
@@ -109,6 +109,19 @@ describe('extractScene (table-driven)', () => {
     expect(diag.map((d) => d.code)).toContain(GeordiErrorCode.E_DIRECTIVE_ARG_MISSING);
   });
 
+  it('wrong required argument type → GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE', () => {
+    const doc = parse(`
+      type Scene @geordi_scene(v: 1, width: "800", height: 600) { _: String }
+    `);
+    const diag: Diagnostic[] = [];
+    const scene = extractScene(doc, diag, 'test.graphql');
+
+    expect(scene).toBeUndefined();
+    const errors = diag.filter((d) => d.severity === 'error');
+    expect(errors.map((d) => d.code)).toContain(GeordiErrorCode.E_DIRECTIVE_ARG_INVALID_TYPE);
+    expect(errors.map((d) => d.code)).not.toContain(GeordiErrorCode.E_DIRECTIVE_ARG_MISSING);
+  });
+
   it('has sourceRef with correct file', () => {
     const doc = parse(`
       type Terminal @geordi_scene(v: "1", width: 800, height: 600) { _: String }


### PR DESCRIPTION
## Summary
- preserve adapter-thrown compiler diagnostics across the schema-graphql to compiler-core boundary
- add DiagnosticsError for collected diagnostics and use it for scene extraction failures
- replace unsafe GraphQL directive argument casts with typed runtime readers that reject wrong literal types, invalid props JSON, unsafe integers, and non-finite numeric literals
- update backlog, bearing, status, design laws, and changelog to mark these P0 items complete

## Verification
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm test:docs
- pnpm test:package-names
- pnpm test:repo-sludge
- git diff --check