### PR TITLE
Fix fail-loud known directives

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -56,21 +56,6 @@ Acceptance criteria:
 
 ---
 
-### Lower or explicitly reject every known Geordi directive
-**Priority**: P0
-**Source**: Repo audit, fail-loud principle
-
-`geordi_bind` and `geordi_style` are declared and treated as known directives, but they are not
-lowered into canonical AST or IR. Known directives must not be silently dropped.
-
-Acceptance criteria:
-- `geordi_bind` lowers into `bindings[]`, or returns an explicit unsupported-feature diagnostic.
-- `geordi_style` lowers into node style data, or returns an explicit unsupported-feature diagnostic.
-- Unknown `geordi_*` directives still produce the intended warning behavior.
-- No known Geordi directive is ignored without a diagnostic.
-
----
-
 ### Expand package contract tests beyond smoke coverage
 **Priority**: P0
 **Source**: Repo audit
@@ -108,6 +93,8 @@ historical context.
 - GraphQL `@geordi_scene` and `@geordi_node` directive arguments are read through typed runtime
   extractors; wrong literal types, non-finite numeric values, and invalid `props` JSON object
   payloads produce `GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE`.
+- Known but unlowered GraphQL directives, currently `geordi_bind` and `geordi_style`, fail loudly
+  with `GEORDI_E_FEATURE_NOT_IMPLEMENTED`; unknown future `geordi_*` directives remain warnings.
 
 ---
 

--- a/BEARING.md
+++ b/BEARING.md
@@ -27,13 +27,12 @@ Completed:
 - Typed adapter diagnostics survive through `compile()` without internal-invariant wrapping.
 - GraphQL `@geordi_scene` and `@geordi_node` directive arguments are validated at runtime before
   values enter the canonical AST.
+- Known but unlowered GraphQL directives fail loudly instead of disappearing from the pipeline.
 
 Still true:
 
 - `geordi-ir/1` is emitted by `compiler-core`, but `core` and `runtime-webgl` still expose an
   older scene shape.
-- Known directives such as `geordi_bind` and `geordi_style` are declared but not lowered or
-  hard-rejected.
 - The graphics numeric profile is only partially defined. JSON is deterministic, but geometry,
   vectors, matrices, transforms, and runtime capability declaration are not fully specified.
 
@@ -43,15 +42,15 @@ Still true:
    - GitHub Actions Dependabot PR #10 was mergeable and has been merged.
    - Conflicting npm Dependabot PR #8 should be recreated by Dependabot before any manual lockfile
      work.
-2. Next focused stabilization target: lower or explicitly reject every known Geordi directive.
-3. Do not start runtime migration before known directive semantics are fail-loud.
+2. Next focused stabilization target: expand package contract tests from entrypoint smoke to
+   behavior coverage.
+3. Do not start runtime migration before package contract tests cover behavior, not only imports.
 
 ## Recommended P0 Order
 
-1. Lower or explicitly reject every known Geordi directive.
-2. Expand package contract tests from entrypoint smoke to behavior coverage.
-3. Move `geordi-ir/1` into `@flyingrobots/geordi-core` as the runtime contract.
-4. Define and enforce the graphics numeric profile.
+1. Expand package contract tests from entrypoint smoke to behavior coverage.
+2. Move `geordi-ir/1` into `@flyingrobots/geordi-core` as the runtime contract.
+3. Define and enforce the graphics numeric profile.
 
 ## Dependency Work
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - `compiler-core/errors`: add `DiagnosticsError` to carry collected diagnostics across adapter boundaries without losing error codes or locations
 - `schema-graphql/adapter`: missing-scene extraction now reports `GEORDI_E_SCENE_MISSING` through `compile()` without duplicate internal-invariant diagnostics
 - `schema-graphql/directives`: replace unsafe directive argument casts with typed runtime readers for `@geordi_scene` and `@geordi_node`; wrong literal types, non-finite numeric literals, and invalid `props` JSON object payloads emit `GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE`
+- `schema-graphql/directives`: `geordi_bind` and `geordi_style` now fail loudly with `GEORDI_E_FEATURE_NOT_IMPLEMENTED` instead of being silently ignored
 - `compiler-core/compile`: `emit.binaryPack: true` now fails before any artifacts are emitted, matching the hard-failure behavior of other unsupported artifact targets
 - `compiler-core/compile`: removed wall-clock `elapsedMs` from `CompileMetadata`; compile results now remain deterministic for identical inputs
 - `emitIr`: O(n²) `shift()`+re-sort queue replaced with `qi`-pointer dequeue and batch merge of newly-ready children — O(n log n) for tree-structured graphs

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -103,20 +103,19 @@ Immediate:
 1. Keep dependency hygiene clean.
    - GitHub Actions Dependabot update PR #10 has been merged.
    - npm/yarn Dependabot PR #8 was stale and conflicting; Dependabot has been asked to recreate it.
-2. Explicitly lower or reject all known Geordi directives.
+2. Expand `wesley-generator` and `runtime-webgl` tests beyond public entrypoint shape.
 
 Short term:
 
-3. Expand `wesley-generator` and `runtime-webgl` tests beyond public entrypoint shape.
-4. Move versioned `geordi-ir/1` types and validation into `@flyingrobots/geordi-core`.
-5. Update `runtime-webgl` to consume the `geordi-ir/1` runtime contract.
+3. Move versioned `geordi-ir/1` types and validation into `@flyingrobots/geordi-core`.
+4. Update `runtime-webgl` to consume the `geordi-ir/1` runtime contract.
 
 Medium term:
 
-6. Define the graphics numeric profile for geometry, vectors, matrices, transforms, and runtime
+5. Define the graphics numeric profile for geometry, vectors, matrices, transforms, and runtime
    capability requirements.
-7. Add source maps and diagnostic UX improvements.
-8. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
+6. Add source maps and diagnostic UX improvements.
+7. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
 
 ## Decision Log
 

--- a/docs/V0_DESIGN_LAWS.md
+++ b/docs/V0_DESIGN_LAWS.md
@@ -433,7 +433,7 @@ Add a root flat ESLint config or downgrade intentionally. CI currently runs lint
 
 Move versioned IR types and validation into `@flyingrobots/geordi-core`. Update `runtime-webgl` to accept validated IR directly or expose only an internal preparation step.
 
-**Status**: Open.
+**Status**: Completed. `geordi_bind` and `geordi_style` now emit source-located `GEORDI_E_FEATURE_NOT_IMPLEMENTED` diagnostics until they are deliberately lowered.
 
 ### P0: Implement or remove canonicalization
 

--- a/packages/schema-graphql/src/parse/extractNodes.ts
+++ b/packages/schema-graphql/src/parse/extractNodes.ts
@@ -29,6 +29,7 @@ export interface ExtractedNode {
 }
 
 const KNOWN_GEORDI_DIRS = new Set(['geordi_scene', 'geordi_node', 'geordi_bind', 'geordi_style']);
+const UNLOWERED_GEORDI_DIRS = new Set(['geordi_bind', 'geordi_style']);
 
 /**
  * Extracts all @geordi_node field definitions from the scene type.
@@ -47,9 +48,19 @@ export function extractNodes(
     const field = fields[i];
     const sourceRef = nodeSourceRef(field, filename);
 
-    // Check for unknown geordi_* directives (warn only for geordi_ prefixed)
+    // Check Geordi directives before lowering the node payload.
     if (field.directives) {
       for (const dir of field.directives) {
+        if (UNLOWERED_GEORDI_DIRS.has(dir.name.value)) {
+          pushUnloweredDirectiveError(
+            diagnostics,
+            field.name.value,
+            dir.name.value,
+            nodeSourceRef(dir, filename),
+          );
+          continue;
+        }
+
         if (dir.name.value.startsWith('geordi_') && !KNOWN_GEORDI_DIRS.has(dir.name.value)) {
           diagnostics.push({
             code: GeordiErrorCode.W_UNUSED_FIELD,
@@ -156,6 +167,28 @@ function pushPropsInvalidType(
           directive: 'geordi_node',
           argument: 'props',
           expected: 'json-object-string',
+        },
+      },
+    ).toDiagnostic(),
+  );
+}
+
+function pushUnloweredDirectiveError(
+  diagnostics: Diagnostic[],
+  fieldName: string,
+  directiveName: string,
+  sourceRef: SourceRef,
+): void {
+  diagnostics.push(
+    new ParseError(
+      GeordiErrorCode.E_FEATURE_NOT_IMPLEMENTED,
+      `@${directiveName} on field "${fieldName}" is declared but is not lowered into canonical AST yet`,
+      {
+        location: sourceRef,
+        details: {
+          directive: directiveName,
+          field: fieldName,
+          phase: 'schema-graphql',
         },
       },
     ).toDiagnostic(),

--- a/packages/schema-graphql/test/e2e.terminal.test.ts
+++ b/packages/schema-graphql/test/e2e.terminal.test.ts
@@ -178,4 +178,26 @@ describe('e2e: Terminal SDL fixture', () => {
       GeordiErrorCode.E_DIRECTIVE_ARG_INVALID_TYPE,
     );
   });
+
+  it('fails loudly when known directives are declared but not lowered', async () => {
+    const result = await compile(
+      makeInput(
+        `
+        type S @geordi_scene(v: "1", width: 100, height: 100) {
+          n: String
+            @geordi_node(kind: Rect)
+            @geordi_bind(targetProp: "props.fill", expr: "theme.primary")
+        }
+      `,
+        'unsupported-directive.graphql',
+      ),
+      DEPS,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics.map((d) => d.code)).toContain(
+      GeordiErrorCode.E_FEATURE_NOT_IMPLEMENTED,
+    );
+    expect(result.diagnostics.map((d) => d.code)).not.toContain(GeordiErrorCode.W_UNUSED_FIELD);
+  });
 });

--- a/packages/schema-graphql/test/extractNodes.test.ts
+++ b/packages/schema-graphql/test/extractNodes.test.ts
@@ -112,6 +112,29 @@ describe('extractNodes (table-driven)', () => {
     expect(warnings.map((w) => w.code)).toContain(GeordiErrorCode.W_UNUSED_FIELD);
   });
 
+  it('known unlowered directives emit GEORDI_E_FEATURE_NOT_IMPLEMENTED errors', () => {
+    const diag: Diagnostic[] = [];
+    parseAndExtract(
+      `
+      type S @geordi_scene(v: "1", width: 100, height: 100) {
+        n: String
+          @geordi_node(kind: Rect, x: 0, y: 0)
+          @geordi_bind(targetProp: "props.fill", expr: "theme.primary")
+          @geordi_style(shadow: "{\\"blur\\":4}")
+      }
+    `,
+      diag,
+    );
+
+    const errors = diag.filter((d) => d.severity === 'error');
+    expect(errors.map((d) => d.code)).toEqual([
+      GeordiErrorCode.E_FEATURE_NOT_IMPLEMENTED,
+      GeordiErrorCode.E_FEATURE_NOT_IMPLEMENTED,
+    ]);
+    expect(errors.map((d) => d.details?.directive)).toEqual(['geordi_bind', 'geordi_style']);
+    expect(diag.map((d) => d.code)).not.toContain(GeordiErrorCode.W_UNUSED_FIELD);
+  });
+
   it('parses props JSON arg into object', () => {
     const diag: Diagnostic[] = [];
     const { nodes } = parseAndExtract(


### PR DESCRIPTION
## Summary
- make declared but unlowered Geordi directives fail loudly instead of disappearing from the schema pipeline
- emit GEORDI_E_FEATURE_NOT_IMPLEMENTED for geordi_bind and geordi_style with source locations and directive details
- keep unknown future geordi_* directives on the existing warning path
- update backlog, bearing, status, design laws, and changelog to mark this P0 complete

## Verification
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm test:docs
- pnpm test:package-names
- pnpm test:repo-sludge
- git diff --check