### PR TITLE
Test package behavior contracts

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -56,21 +56,6 @@ Acceptance criteria:
 
 ---
 
-### Expand package contract tests beyond smoke coverage
-**Priority**: P0
-**Source**: Repo audit
-
-`@flyingrobots/geordi-runtime-webgl` and `@flyingrobots/geordi-wesley-generator` now have public
-entrypoint contract tests, and the repo has a placeholder-test guard. They still need behavior tests
-that prove the runtime and generator contracts rather than only import shape.
-
-Acceptance criteria:
-- `wesley-generator` tests plan/generate on minimal SDL and asserts emitted artifacts.
-- `runtime-webgl` tests the selected IR input contract, with a canvas/context mock if needed.
-- Keep the post-build package import smoke test in CI.
-
----
-
 ## Completed Stabilization Work
 
 These P0 items were completed in the 2026-05-22 stabilization work and are retained here as
@@ -95,6 +80,9 @@ historical context.
   payloads produce `GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE`.
 - Known but unlowered GraphQL directives, currently `geordi_bind` and `geordi_style`, fail loudly
   with `GEORDI_E_FEATURE_NOT_IMPLEMENTED`; unknown future `geordi_*` directives remain warnings.
+- Package contract tests now exercise behavior: `wesley-generator` plans/generates artifacts from
+  minimal SDL and fails with a custom error on bad SDL, while `runtime-webgl` renders the current
+  scene contract against a canvas/context mock.
 
 ---
 

--- a/BEARING.md
+++ b/BEARING.md
@@ -28,6 +28,8 @@ Completed:
 - GraphQL `@geordi_scene` and `@geordi_node` directive arguments are validated at runtime before
   values enter the canonical AST.
 - Known but unlowered GraphQL directives fail loudly instead of disappearing from the pipeline.
+- `wesley-generator` and `runtime-webgl` have behavior-level package contract tests, not only
+  entrypoint smoke tests.
 
 Still true:
 
@@ -42,15 +44,14 @@ Still true:
    - GitHub Actions Dependabot PR #10 was mergeable and has been merged.
    - Conflicting npm Dependabot PR #8 should be recreated by Dependabot before any manual lockfile
      work.
-2. Next focused stabilization target: expand package contract tests from entrypoint smoke to
-   behavior coverage.
-3. Do not start runtime migration before package contract tests cover behavior, not only imports.
+2. Next focused stabilization target: move `geordi-ir/1` into `@flyingrobots/geordi-core` as the
+   runtime contract.
+3. Keep the graphics numeric profile explicit while migrating runtime-facing types.
 
 ## Recommended P0 Order
 
-1. Expand package contract tests from entrypoint smoke to behavior coverage.
-2. Move `geordi-ir/1` into `@flyingrobots/geordi-core` as the runtime contract.
-3. Define and enforce the graphics numeric profile.
+1. Move `geordi-ir/1` into `@flyingrobots/geordi-core` as the runtime contract.
+2. Define and enforce the graphics numeric profile.
 
 ## Dependency Work
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 ### Tests
 
+- **`@flyingrobots/geordi-wesley-generator`**: add behavior contract tests for `plan()`, successful SDL-to-artifacts generation, and custom failure errors on bad SDL
+- **`@flyingrobots/geordi-runtime-webgl`**: add canvas/context mock behavior tests for rendering the current scene contract and context-unavailable failure
 - **`@flyingrobots/geordi-compiler-core`**: 74 new tests across sprint 3 — first batch: `stableStringify` (22), `parseInput` table-driven (9), `determinism` (3) → 36 tests; second batch: `validateAst` (15), `emitTypes` (19), `determinism` +4, `compile.golden` +3 → total 79 tests
 - **`@flyingrobots/geordi-schema-graphql`**: 42 new tests — `extractScene` (10), `extractNodes` (10), `toCanonicalAst` (14), `e2e.terminal` (8)
 - Cycle detection verifies Tier 2 is suppressed when Tier 1 errors present

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -103,19 +103,15 @@ Immediate:
 1. Keep dependency hygiene clean.
    - GitHub Actions Dependabot update PR #10 has been merged.
    - npm/yarn Dependabot PR #8 was stale and conflicting; Dependabot has been asked to recreate it.
-2. Expand `wesley-generator` and `runtime-webgl` tests beyond public entrypoint shape.
+2. Move versioned `geordi-ir/1` types and validation into `@flyingrobots/geordi-core`.
+3. Update `runtime-webgl` to consume the `geordi-ir/1` runtime contract.
 
 Short term:
 
-3. Move versioned `geordi-ir/1` types and validation into `@flyingrobots/geordi-core`.
-4. Update `runtime-webgl` to consume the `geordi-ir/1` runtime contract.
-
-Medium term:
-
-5. Define the graphics numeric profile for geometry, vectors, matrices, transforms, and runtime
+4. Define the graphics numeric profile for geometry, vectors, matrices, transforms, and runtime
    capability requirements.
-6. Add source maps and diagnostic UX improvements.
-7. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
+5. Add source maps and diagnostic UX improvements.
+6. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
 
 ## Decision Log
 

--- a/docs/V0_DESIGN_LAWS.md
+++ b/docs/V0_DESIGN_LAWS.md
@@ -470,8 +470,8 @@ Adapter failures should preserve `GEORDI_E_INPUT_INVALID_SDL`, `GEORDI_E_SCENE_M
 
 `runtime-webgl` and `wesley-generator` need tests that exercise public behavior, not placeholder assertions. Include post-build import smoke tests and at least one SDL-to-artifacts integration path.
 
-**Status**: Partially complete. Placeholder assertions are blocked by CI and package entrypoints are
-smoke-tested. Behavior tests for `runtime-webgl` and `wesley-generator` remain open.
+**Status**: Completed. Placeholder assertions are blocked by CI, package entrypoints are
+smoke-tested, and `runtime-webgl` plus `wesley-generator` now have behavior-level contract tests.
 
 ### P0: Remove tracked generated logs and stale nested lockfiles
 

--- a/packages/runtime-webgl/src/index.test.ts
+++ b/packages/runtime-webgl/src/index.test.ts
@@ -1,9 +1,201 @@
-import { describe, expect, it } from 'vitest';
-import { GeordiWebGLRenderer, renderGeordiToCanvas } from './index';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { GeordiScene } from '@flyingrobots/geordi-core';
+import {
+  GeordiCanvasContextUnavailableError,
+  GeordiWebGLRenderer,
+  renderGeordiToCanvas,
+} from './index';
+
+interface CanvasCall {
+  readonly name: string;
+  readonly args: readonly (number | string)[];
+}
+
+class FakeCanvasContext2D {
+  fillStyle: string | CanvasGradient | CanvasPattern = '';
+  strokeStyle: string | CanvasGradient | CanvasPattern = '';
+  lineWidth = 1;
+  globalAlpha = 1;
+  font = '';
+  textBaseline: CanvasTextBaseline = 'alphabetic';
+  textAlign: CanvasTextAlign = 'start';
+  readonly calls: CanvasCall[] = [];
+
+  fillRect(x: number, y: number, width: number, height: number): void {
+    this.push('fillRect', x, y, width, height);
+  }
+
+  save(): void {
+    this.push('save');
+  }
+
+  restore(): void {
+    this.push('restore');
+  }
+
+  beginPath(): void {
+    this.push('beginPath');
+  }
+
+  closePath(): void {
+    this.push('closePath');
+  }
+
+  rect(x: number, y: number, width: number, height: number): void {
+    this.push('rect', x, y, width, height);
+  }
+
+  fill(): void {
+    this.push('fill');
+  }
+
+  stroke(): void {
+    this.push('stroke');
+  }
+
+  moveTo(x: number, y: number): void {
+    this.push('moveTo', x, y);
+  }
+
+  lineTo(x: number, y: number): void {
+    this.push('lineTo', x, y);
+  }
+
+  arcTo(x1: number, y1: number, x2: number, y2: number, radius: number): void {
+    this.push('arcTo', x1, y1, x2, y2, radius);
+  }
+
+  fillText(text: string, x: number, y: number): void {
+    this.push('fillText', text, x, y);
+  }
+
+  private push(name: string, ...args: (number | string)[]): void {
+    this.calls.push({ name, args });
+  }
+}
+
+const hadDocument = Object.prototype.hasOwnProperty.call(globalThis, 'document');
+const originalDocument = hadDocument ? globalThis.document : undefined;
+
+afterEach(() => {
+  if (hadDocument && originalDocument) {
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: originalDocument,
+    });
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, 'document');
+});
+
+function makeCanvas(context: CanvasRenderingContext2D | null): HTMLCanvasElement {
+  return {
+    width: 0,
+    height: 0,
+    getContext: (contextId: string) => (contextId === '2d' ? context : null),
+  } as object as HTMLCanvasElement;
+}
+
+function installCanvasDocument(canvas: HTMLCanvasElement): void {
+  const fakeDocument = {
+    createElement: (tagName: string) => {
+      expect(tagName).toBe('canvas');
+      return canvas;
+    },
+  } as object as Document;
+
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: fakeDocument,
+  });
+}
+
+function makeScene(): GeordiScene {
+  return {
+    version: '0.1.0',
+    meta: {
+      generator: 'test',
+      source: 'test',
+      hash: 'sha256:test',
+    },
+    canvas: {
+      width: 100,
+      height: 50,
+      units: 'px',
+      origin: 'top-left',
+    },
+    nodes: [
+      {
+        id: 'rect-1',
+        type: 'rect',
+        bounds: [1, 2, 10, 20],
+        static: true,
+        style: {
+          paint: {
+            fill: {
+              type: 'solid',
+              color: '#123456',
+            },
+          },
+        },
+      },
+      {
+        id: 'text-1',
+        type: 'text',
+        bounds: [5, 6, 80, 12],
+        static: true,
+        content: 'Hello',
+        style: {
+          text: {
+            font: 'Inter',
+            size: 12,
+            weight: 400,
+            color: '#ffffff',
+          },
+        },
+      },
+    ],
+    tokens: {},
+  };
+}
 
 describe('runtime-webgl public API', () => {
   it('exports renderer entrypoints', () => {
     expect(GeordiWebGLRenderer).toBeTypeOf('function');
     expect(renderGeordiToCanvas).toBeTypeOf('function');
+  });
+
+  it('renders the current scene contract to a canvas context', () => {
+    const context = new FakeCanvasContext2D();
+    const canvas = makeCanvas(context as object as CanvasRenderingContext2D);
+    installCanvasDocument(canvas);
+
+    const rendered = renderGeordiToCanvas(makeScene());
+
+    expect(rendered).toBe(canvas);
+    expect(canvas.width).toBe(100);
+    expect(canvas.height).toBe(50);
+    expect(context.calls).toEqual([
+      { name: 'fillRect', args: [0, 0, 100, 50] },
+      { name: 'save', args: [] },
+      { name: 'beginPath', args: [] },
+      { name: 'rect', args: [1, 2, 10, 20] },
+      { name: 'closePath', args: [] },
+      { name: 'fill', args: [] },
+      { name: 'restore', args: [] },
+      { name: 'save', args: [] },
+      { name: 'fillText', args: ['Hello', 5, 6] },
+      { name: 'restore', args: [] },
+    ]);
+    expect(context.font).toBe('400 12px Inter');
+  });
+
+  it('throws a custom error when a canvas context cannot be created', () => {
+    installCanvasDocument(makeCanvas(null));
+
+    expect(() => new GeordiWebGLRenderer(10, 10)).toThrow(
+      GeordiCanvasContextUnavailableError,
+    );
   });
 });

--- a/packages/runtime-webgl/src/index.ts
+++ b/packages/runtime-webgl/src/index.ts
@@ -4,5 +4,5 @@
  * WebGL/Canvas renderer for Geordi scenes
  */
 
-export { GeordiWebGLRenderer } from './WebGLRenderer.js';
+export { GeordiCanvasContextUnavailableError, GeordiWebGLRenderer } from './WebGLRenderer.js';
 export { renderGeordiToCanvas } from './utils.js';

--- a/packages/wesley-generator/src/index.test.ts
+++ b/packages/wesley-generator/src/index.test.ts
@@ -1,8 +1,97 @@
 import { describe, expect, it } from 'vitest';
-import { GeordiGeneratorPlugin } from './index';
+import { parseJsonValue } from '@flyingrobots/geordi-compiler-core';
+import type { GeordiIrV1 } from '@flyingrobots/geordi-compiler-core';
+import { GeordiGenerationFailedError, GeordiGeneratorPlugin } from './index';
+
+const MINIMAL_SDL = `
+type Scene @geordi_scene(v: "1", width: 320, height: 200) {
+  bg: String @geordi_node(kind: Rect, width: 320, height: 200, props: "{\\"fill\\":\\"#101010\\"}")
+}
+`;
+
+interface CapturedLogs {
+  readonly info: string[];
+  readonly warn: string[];
+  readonly error: string[];
+}
+
+function makeLogs(): CapturedLogs {
+  return {
+    info: [],
+    warn: [],
+    error: [],
+  };
+}
+
+function makeContext(logs: CapturedLogs) {
+  return {
+    logger: {
+      info: (msg: string) => logs.info.push(msg),
+      warn: (msg: string) => logs.warn.push(msg),
+      error: (msg: string) => logs.error.push(msg),
+    },
+  };
+}
+
+function stringArtifact(
+  output: Record<string, string | Uint8Array>,
+  path: string,
+): string {
+  const content = output[path];
+  expect(content).toBeTypeOf('string');
+  return typeof content === 'string' ? content : '';
+}
 
 describe('wesley-generator public API', () => {
   it('exports GeordiGeneratorPlugin', () => {
     expect(GeordiGeneratorPlugin).toBeTypeOf('function');
+  });
+
+  it('plans and generates Geordi artifacts from minimal SDL', async () => {
+    const plugin = new GeordiGeneratorPlugin();
+    const logs = makeLogs();
+    const context = makeContext(logs);
+
+    const plan = plugin.plan({ sdl: MINIMAL_SDL }, context);
+    expect(plan.artifacts.map((artifact) => artifact.path)).toEqual([
+      'scene.geordi.json',
+      'types.ts',
+    ]);
+    expect(plan.metadata).toEqual({
+      inputFormat: 'graphql-sdl',
+      sdl: MINIMAL_SDL,
+    });
+
+    const output = await plugin.generate(plan, context);
+    expect(Object.keys(output).sort()).toEqual([
+      'scene.geordi.json',
+      'scene.geordi.json.receipt',
+      'types.ts',
+    ]);
+
+    const ir = parseJsonValue(stringArtifact(output, 'scene.geordi.json')) as GeordiIrV1;
+    expect(ir.irVersion).toBe('geordi-ir/1');
+    expect(ir.scene.width).toBe(320);
+    expect(ir.scene.height).toBe(200);
+    expect(ir.nodes).toHaveLength(1);
+
+    const types = stringArtifact(output, 'types.ts');
+    expect(types).toContain('export interface SceneRoot');
+    expect(logs.error).toHaveLength(0);
+  });
+
+  it('throws a custom failure error and logs diagnostics when compilation fails', async () => {
+    const plugin = new GeordiGeneratorPlugin();
+    const logs = makeLogs();
+    const context = makeContext(logs);
+    const plan = plugin.plan({ sdl: 'type Broken {' }, context);
+    const generation = plugin.generate(plan, context);
+
+    await expect(generation).rejects.toBeInstanceOf(GeordiGenerationFailedError);
+    await expect(generation).rejects.toMatchObject({
+      errorCount: 1,
+      name: 'GeordiGenerationFailedError',
+    });
+    expect(logs.error.join('\n')).toContain('GEORDI_E_INPUT_INVALID_SDL');
   });
 });

--- a/packages/wesley-generator/src/index.ts
+++ b/packages/wesley-generator/src/index.ts
@@ -1,1 +1,1 @@
-export { GeordiGeneratorPlugin } from './GeordiGeneratorPlugin.js';
+export { GeordiGenerationFailedError, GeordiGeneratorPlugin } from './GeordiGeneratorPlugin.js';


### PR DESCRIPTION
## Summary
- add wesley-generator behavior tests for plan(), successful SDL-to-artifacts generation, and bad-SDL failure logging
- add runtime-webgl behavior tests using a canvas/context mock for rendering and context-unavailable failure
- export package custom error types used by the behavior contracts
- update backlog, bearing, status, design laws, and changelog to mark this P0 complete

## Verification
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm test:docs
- pnpm test:package-names
- pnpm test:repo-sludge
- git diff --check