### PR TITLE
[codex] Move IR contract into core runtime path

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -21,6 +21,10 @@ These open items come from the repo audit and the v0 design pass. See
 ### Make `geordi-ir/1` the runtime contract
 **Priority**: P0
 **Source**: v0 design laws, repo audit
+**Status**: In progress. Core now owns versioned `geordi-ir/1` types and structural validation,
+compiler-core emits/re-exports that shared contract, and runtime-webgl has a typed IR preparation
+and render path. The remaining release-blocker is retiring or explicitly deprecating the older
+public scene shape before v0.1.
 
 `@flyingrobots/geordi-compiler-core` emits `geordi-ir/1`, while `@flyingrobots/geordi-core` and
 `@flyingrobots/geordi-runtime-webgl` still model/render an older `version`/`canvas`/`type`/`bounds`

--- a/BEARING.md
+++ b/BEARING.md
@@ -1,8 +1,8 @@
 # Geordi Bearing
 
 **Date**: 2026-05-22
-**Branch baseline**: `main` at `9287157`
-**Current head when written**: `9287157`
+**Branch baseline**: `main` at `16395d0`
+**Current head when written**: `16395d0`
 
 This file is the short-term operating map. Product rationale remains in
 [`docs/V0_DESIGN_LAWS.md`](./docs/V0_DESIGN_LAWS.md); detailed work items remain in
@@ -30,11 +30,15 @@ Completed:
 - Known but unlowered GraphQL directives fail loudly instead of disappearing from the pipeline.
 - `wesley-generator` and `runtime-webgl` have behavior-level package contract tests, not only
   entrypoint smoke tests.
+- `@flyingrobots/geordi-core` owns versioned `geordi-ir/1` constants, types, and structural
+  validation.
+- `@flyingrobots/geordi-compiler-core` emits/re-exports the shared core IR contract.
+- `@flyingrobots/geordi-runtime-webgl` can prepare and render typed `geordi-ir/1` through the
+  existing canvas renderer.
 
 Still true:
 
-- `geordi-ir/1` is emitted by `compiler-core`, but `core` and `runtime-webgl` still expose an
-  older scene shape.
+- `runtime-webgl` still exposes the older `GeordiScene` rendering path during migration.
 - The graphics numeric profile is only partially defined. JSON is deterministic, but geometry,
   vectors, matrices, transforms, and runtime capability declaration are not fully specified.
 
@@ -44,13 +48,13 @@ Still true:
    - GitHub Actions Dependabot PR #10 was mergeable and has been merged.
    - Conflicting npm Dependabot PR #8 should be recreated by Dependabot before any manual lockfile
      work.
-2. Next focused stabilization target: move `geordi-ir/1` into `@flyingrobots/geordi-core` as the
-   runtime contract.
+2. Finish the runtime-contract migration by making the public renderer API prefer `geordi-ir/1`
+   and by deprecating, renaming, or internalizing the legacy scene shape.
 3. Keep the graphics numeric profile explicit while migrating runtime-facing types.
 
 ## Recommended P0 Order
 
-1. Move `geordi-ir/1` into `@flyingrobots/geordi-core` as the runtime contract.
+1. Finish making `geordi-ir/1` the public runtime contract.
 2. Define and enforce the graphics numeric profile.
 
 ## Dependency Work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 
 ### Features
 
+- **`@flyingrobots/geordi-core`**: Add core-owned `geordi-ir/1` constants, versioned IR types,
+  and structural validation for scenes, nodes, bindings, animations, keyframes, and finite
+  numeric fields.
+- **`@flyingrobots/geordi-compiler-core`**: Re-export IR types from
+  `@flyingrobots/geordi-core` and emit the shared core IR constants for artifact keys, receipt
+  keys, version, and hash algorithm.
+- **`@flyingrobots/geordi-runtime-webgl`**: Add a typed `geordi-ir/1` preparation path plus
+  `renderGeordiIrToCanvas()` so runtime callers can render core-owned IR through the existing
+  canvas renderer while legacy scene rendering remains available during migration.
 - **`@flyingrobots/geordi-compiler-core`**: Semantic validation engine — `validateCanonicalAst()` with two-tier rule registry; Tier 1 (structural: `sceneDimensions`, `nodeKindValid`, `duplicateId`, `danglingRef`, `cycleDetection`) gates Tier 2 (semantic: `requiredProps` per NodeKind); iterative Kahn's cycle detection passes 10k-node chains without stack overflow
 - **`@flyingrobots/geordi-compiler-core`**: Deterministic IR emitter — `emitGeordiIrArtifact()` replaces stub; two-phase topological sort (Kahn's on `parentId` DAG, tie-broken `zIndex ASC → kind ASC → id ASC` bytewise); strips `sourceRef` and `__typename`
 - **`@flyingrobots/geordi-compiler-core`**: Determinism certificate — `emitReceiptArtifact()` emits `scene.geordi.json.receipt` alongside IR containing `comparatorVersion`, `inputHash` (SHA-256 of `input.source`), `irHash` (SHA-256 of the emitted IR), `irHashAlg` (`"sha256"`), `irVersion`, and `rulesetFingerprint` (SHA-256 of sorted rule IDs)
@@ -28,6 +37,12 @@
 
 ### Tests
 
+- **`@flyingrobots/geordi-core`**: add `geordi-ir/1` validation coverage for valid IR, version
+  mismatch, non-finite numbers, and malformed node props.
+- **`@flyingrobots/geordi-compiler-core`**: add a compiler-to-core contract test proving emitted
+  IR parses through the canonical JSON port and validates under the core-owned IR contract.
+- **`@flyingrobots/geordi-runtime-webgl`**: add coverage for rendering `geordi-ir/1` through the
+  new runtime preparation path.
 - **`@flyingrobots/geordi-wesley-generator`**: add behavior contract tests for `plan()`, successful SDL-to-artifacts generation, and custom failure errors on bad SDL
 - **`@flyingrobots/geordi-runtime-webgl`**: add canvas/context mock behavior tests for rendering the current scene contract and context-unavailable failure
 - **`@flyingrobots/geordi-compiler-core`**: 74 new tests across sprint 3 — first batch: `stableStringify` (22), `parseInput` table-driven (9), `determinism` (3) → 36 tests; second batch: `validateAst` (15), `emitTypes` (19), `determinism` +4, `compile.golden` +3 → total 79 tests

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -17,7 +17,7 @@ semantic correctness rather than more repository scaffolding.
 
 Pure, framework-agnostic compilation engine.
 
-- Type system: canonical AST, IR, diagnostics, artifacts.
+- Type system: canonical AST, diagnostics, artifacts, and IR types re-exported from core.
 - Error taxonomy with stable `GEORDI_E_*` and `GEORDI_W_*` codes.
 - Compile orchestrator with parse, canonicalize, validate, and emit phases.
 - GraphQL SDL and canonical JSON input paths.
@@ -49,7 +49,8 @@ Wesley GeneratorPlugin adapter scaffold.
 Core domain package.
 
 - Current domain models and guards for the older scene shape.
-- Still needs migration to own validated `geordi-ir/1` runtime contract types.
+- Versioned `geordi-ir/1` constants, structural types, and validation.
+- Still needs the older scene shape deprecated, renamed, or internalized before v0.1.
 
 #### `@flyingrobots/geordi-runtime-webgl`
 
@@ -57,7 +58,8 @@ Canvas-backed WebGL-runtime scaffold.
 
 - Basic renderer implementation.
 - Public entrypoint contract test.
-- Still consumes the older `GeordiScene` shape and must migrate to `geordi-ir/1`.
+- Typed `geordi-ir/1` preparation path and `renderGeordiIrToCanvas()` adapter.
+- Still exposes the older `GeordiScene` path during migration.
 
 ## Infrastructure
 
@@ -75,16 +77,16 @@ Canvas-backed WebGL-runtime scaffold.
 
 ## Test Status
 
-Latest full local gate during the stabilization merge:
+Latest full local gate during the core IR runtime-contract work:
 
 | Package | Tests | Status |
 | --- | ---: | --- |
-| `@flyingrobots/geordi-compiler-core` | 71 | Green |
-| `@flyingrobots/geordi-schema-graphql` | 42 | Green |
-| `@flyingrobots/geordi-core` | 7 | Green |
-| `@flyingrobots/geordi-runtime-webgl` | 1 | Green |
-| `@flyingrobots/geordi-wesley-generator` | 1 | Green |
-| **Total package tests** | **122** | Green |
+| `@flyingrobots/geordi-compiler-core` | 73 | Green |
+| `@flyingrobots/geordi-schema-graphql` | 51 | Green |
+| `@flyingrobots/geordi-core` | 11 | Green |
+| `@flyingrobots/geordi-runtime-webgl` | 4 | Green |
+| `@flyingrobots/geordi-wesley-generator` | 3 | Green |
+| **Total package tests** | **142** | Green |
 
 Additional gates:
 
@@ -103,8 +105,10 @@ Immediate:
 1. Keep dependency hygiene clean.
    - GitHub Actions Dependabot update PR #10 has been merged.
    - npm/yarn Dependabot PR #8 was stale and conflicting; Dependabot has been asked to recreate it.
-2. Move versioned `geordi-ir/1` types and validation into `@flyingrobots/geordi-core`.
-3. Update `runtime-webgl` to consume the `geordi-ir/1` runtime contract.
+2. Make the runtime public API prefer `geordi-ir/1` and decide the deprecation/internalization path
+   for the older `GeordiScene` model.
+3. Define the validator failure surface for runtime-bound IR: caller-validated only, or explicit
+   runtime validation with custom runtime error types.
 
 Short term:
 

--- a/docs/V0_DESIGN_LAWS.md
+++ b/docs/V0_DESIGN_LAWS.md
@@ -433,7 +433,10 @@ Add a root flat ESLint config or downgrade intentionally. CI currently runs lint
 
 Move versioned IR types and validation into `@flyingrobots/geordi-core`. Update `runtime-webgl` to accept validated IR directly or expose only an internal preparation step.
 
-**Status**: Completed. `geordi_bind` and `geordi_style` now emit source-located `GEORDI_E_FEATURE_NOT_IMPLEMENTED` diagnostics until they are deliberately lowered.
+**Status**: In progress. `@flyingrobots/geordi-core` now owns `geordi-ir/1` constants, types,
+and structural validation. `compiler-core` emits/re-exports the shared contract, and
+`runtime-webgl` has a typed IR preparation/render path. The older public `GeordiScene` shape still
+needs to be deprecated, renamed, or internalized before v0.1.
 
 ### P0: Implement or remove canonicalization
 
@@ -458,7 +461,8 @@ Replace unsafe directive argument casts with typed extractors that emit source-l
 
 Known directives such as `geordi_bind` and `geordi_style` must either lower into canonical AST/IR or produce explicit unsupported-feature diagnostics. Silent drops are not allowed.
 
-**Status**: Open.
+**Status**: Completed. `geordi_bind` and `geordi_style` now emit source-located
+`GEORDI_E_FEATURE_NOT_IMPLEMENTED` diagnostics until they are deliberately lowered.
 
 ### P0: Preserve typed diagnostics across adapter/compiler boundaries
 

--- a/packages/compiler-core/package.json
+++ b/packages/compiler-core/package.json
@@ -15,6 +15,9 @@
   "files": [
     "dist"
   ],
+  "dependencies": {
+    "@flyingrobots/geordi-core": "workspace:*"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",

--- a/packages/compiler-core/src/compile/emitIr.ts
+++ b/packages/compiler-core/src/compile/emitIr.ts
@@ -1,14 +1,20 @@
 import type { CanonicalSceneAst } from '../types/ast.js';
 import type { CompilerInput } from '../types/compiler.js';
 import type { Artifact } from '../types/artifacts.js';
+import {
+  GEORDI_IR_ARTIFACT_KEY,
+  GEORDI_IR_HASH_ALGORITHM,
+  GEORDI_IR_RECEIPT_KEY,
+  GEORDI_IR_VERSION,
+} from '@flyingrobots/geordi-core';
 import { stringifyCanonicalJson } from '../ports/json.js';
 import { hashString } from '../canonical/hashing.js';
 import { cmpStr } from '../util/identifiers.js';
 
 export const COMPARATOR_VERSION = '1' as const;
-export const IR_VERSION = 'geordi-ir/1' as const;
-export const IR_ARTIFACT_KEY = 'scene.geordi.json' as const;
-export const IR_RECEIPT_KEY = 'scene.geordi.json.receipt' as const;
+export const IR_VERSION = GEORDI_IR_VERSION;
+export const IR_ARTIFACT_KEY = GEORDI_IR_ARTIFACT_KEY;
+export const IR_RECEIPT_KEY = GEORDI_IR_RECEIPT_KEY;
 
 /**
  * Phase 1: Topological sort by parentId DAG.
@@ -39,7 +45,7 @@ export function emitGeordiIrArtifact(ast: CanonicalSceneAst): Artifact {
   };
 }
 
-export const IR_HASH_ALG = 'sha256' as const;
+export const IR_HASH_ALG = GEORDI_IR_HASH_ALGORITHM;
 
 export function emitReceiptArtifact(
   input: CompilerInput,

--- a/packages/compiler-core/src/types/ir.ts
+++ b/packages/compiler-core/src/types/ir.ts
@@ -1,50 +1,8 @@
-import type { JsonObject, JsonValue } from './json.js';
-
-// Keep IR explicit and separate from canonical AST.
-export interface GeordiIrSceneV1 extends JsonObject {
-  id: string;
-  width: number;
-  height: number;
-  units?: 'px';
-  background?: string;
-}
-
-export interface GeordiIrNodeV1 extends JsonObject {
-  id: string;
-  kind: string;
-  parentId?: string;
-  zIndex?: number;
-  visible?: boolean;
-  props: JsonObject;
-  style?: JsonObject;
-}
-
-export interface GeordiIrBindingV1 extends JsonObject {
-  id: string;
-  targetNodeId: string;
-  targetProp: string;
-  expression: string;
-  when?: string;
-}
-
-export interface GeordiIrKeyframeV1 extends JsonObject {
-  t: number;
-  value: JsonValue;
-}
-
-export interface GeordiIrAnimationV1 extends JsonObject {
-  id: string;
-  targetNodeId: string;
-  property: string;
-  keyframes: GeordiIrKeyframeV1[];
-  easing?: string;
-  loop?: boolean;
-}
-
-export interface GeordiIrV1 extends JsonObject {
-  irVersion: 'geordi-ir/1';
-  scene: GeordiIrSceneV1;
-  nodes: GeordiIrNodeV1[];
-  bindings?: GeordiIrBindingV1[];
-  animations?: GeordiIrAnimationV1[];
-}
+export type {
+  GeordiIrSceneV1,
+  GeordiIrNodeV1,
+  GeordiIrBindingV1,
+  GeordiIrKeyframeV1,
+  GeordiIrAnimationV1,
+  GeordiIrV1,
+} from '@flyingrobots/geordi-core';

--- a/packages/compiler-core/test/coreIrContract.test.ts
+++ b/packages/compiler-core/test/coreIrContract.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { validateGeordiIrV1 } from '@flyingrobots/geordi-core';
+import { compile } from '../src/compile/compile';
+import { parseJsonValue, stringifyCanonicalJson } from '../src/ports/json';
+
+describe('compiler-core to geordi-core IR contract', () => {
+  it('emits geordi-ir/1 that validates under the core-owned contract', async () => {
+    const source = stringifyCanonicalJson({
+      kind: 'Scene',
+      astVersion: '1',
+      scene: {
+        id: 'scene:core-contract',
+        width: 320,
+        height: 200,
+        units: 'px',
+      },
+      nodes: [
+        {
+          id: 'node:bg',
+          kind: 'Rect',
+          props: {
+            x: 0,
+            y: 0,
+            width: 320,
+            height: 200,
+            fill: '#101010',
+          },
+          visible: true,
+        },
+      ],
+      metadata: { sourceFormat: 'canonical-ast-json' },
+    });
+
+    const result = await compile({
+      format: 'canonical-ast-json',
+      source,
+      options: {
+        target: 'geordi-ir-v1',
+        emit: {
+          irJson: true,
+          tsTypes: false,
+        },
+        canonicalize: true,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    const artifact = result.artifacts['scene.geordi.json'];
+    expect(artifact).toBeDefined();
+
+    const ir = parseJsonValue(String(artifact.content));
+    expect(validateGeordiIrV1(ir)).toEqual({ ok: true, issues: [] });
+  });
+});

--- a/packages/core/src/domain/models/GeordiIr.test.ts
+++ b/packages/core/src/domain/models/GeordiIr.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GEORDI_IR_VERSION,
+  isGeordiIrV1,
+  validateGeordiIrV1,
+} from './GeordiIr';
+
+const VALID_IR = {
+  irVersion: GEORDI_IR_VERSION,
+  scene: {
+    id: 'scene:test',
+    width: 320,
+    height: 200,
+    units: 'px',
+  },
+  nodes: [
+    {
+      id: 'node:bg',
+      kind: 'Rect',
+      zIndex: 0,
+      visible: true,
+      props: {
+        x: 0,
+        y: 0,
+        width: 320,
+        height: 200,
+      },
+    },
+  ],
+  bindings: [],
+  animations: [],
+};
+
+describe('Geordi IR v1 contract', () => {
+  it('accepts a valid geordi-ir/1 document', () => {
+    const result = validateGeordiIrV1(VALID_IR);
+
+    expect(result).toEqual({ ok: true, issues: [] });
+    expect(isGeordiIrV1(VALID_IR)).toBe(true);
+  });
+
+  it('rejects the wrong IR version', () => {
+    const result = validateGeordiIrV1({
+      ...VALID_IR,
+      irVersion: 'geordi-ir/2',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.map((issue) => issue.path)).toContain('$.irVersion');
+  });
+
+  it('rejects non-finite scene dimensions and node z-index', () => {
+    const result = validateGeordiIrV1({
+      ...VALID_IR,
+      scene: {
+        id: 'scene:test',
+        width: Number.NaN,
+        height: Number.POSITIVE_INFINITY,
+      },
+      nodes: [
+        {
+          id: 'node:bg',
+          kind: 'Rect',
+          zIndex: Number.NEGATIVE_INFINITY,
+          props: {},
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.map((issue) => issue.path)).toEqual([
+      '$.scene.width',
+      '$.scene.height',
+      '$.nodes[0].zIndex',
+    ]);
+  });
+
+  it('rejects nodes without object props', () => {
+    const result = validateGeordiIrV1({
+      ...VALID_IR,
+      nodes: [
+        {
+          id: 'node:bg',
+          kind: 'Rect',
+          props: null,
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.map((issue) => issue.path)).toContain('$.nodes[0].props');
+  });
+});

--- a/packages/core/src/domain/models/GeordiIr.ts
+++ b/packages/core/src/domain/models/GeordiIr.ts
@@ -1,0 +1,303 @@
+import type { JsonObject, JsonValue } from './GeordiScene.js';
+
+export const GEORDI_IR_VERSION = 'geordi-ir/1' as const;
+export const GEORDI_IR_ARTIFACT_KEY = 'scene.geordi.json' as const;
+export const GEORDI_IR_RECEIPT_KEY = 'scene.geordi.json.receipt' as const;
+export const GEORDI_IR_HASH_ALGORITHM = 'sha256' as const;
+
+export interface GeordiIrSceneV1 extends JsonObject {
+  readonly id: string;
+  readonly width: number;
+  readonly height: number;
+  readonly units?: 'px';
+  readonly background?: string;
+}
+
+export interface GeordiIrNodeV1 extends JsonObject {
+  readonly id: string;
+  readonly kind: string;
+  readonly parentId?: string;
+  readonly zIndex?: number;
+  readonly visible?: boolean;
+  readonly locked?: boolean;
+  readonly props: JsonObject;
+  readonly style?: JsonObject;
+}
+
+export interface GeordiIrBindingV1 extends JsonObject {
+  readonly id: string;
+  readonly targetNodeId: string;
+  readonly targetProp: string;
+  readonly expression: string;
+  readonly when?: string;
+}
+
+export interface GeordiIrKeyframeV1 extends JsonObject {
+  readonly t: number;
+  readonly value: JsonValue;
+}
+
+export interface GeordiIrAnimationV1 extends JsonObject {
+  readonly id: string;
+  readonly targetNodeId: string;
+  readonly property: string;
+  readonly keyframes: readonly GeordiIrKeyframeV1[];
+  readonly easing?: string;
+  readonly loop?: boolean;
+}
+
+export interface GeordiIrV1 extends JsonObject {
+  readonly irVersion: typeof GEORDI_IR_VERSION;
+  readonly scene: GeordiIrSceneV1;
+  readonly nodes: readonly GeordiIrNodeV1[];
+  readonly bindings?: readonly GeordiIrBindingV1[];
+  readonly animations?: readonly GeordiIrAnimationV1[];
+}
+
+export interface GeordiIrValidationIssue extends JsonObject {
+  readonly path: string;
+  readonly message: string;
+}
+
+export interface GeordiIrValidationResult {
+  readonly ok: boolean;
+  readonly issues: readonly GeordiIrValidationIssue[];
+}
+
+export function isGeordiIrV1(value: JsonValue | undefined): value is GeordiIrV1 {
+  return validateGeordiIrV1(value).ok;
+}
+
+export function validateGeordiIrV1(value: JsonValue | undefined): GeordiIrValidationResult {
+  const issues: GeordiIrValidationIssue[] = [];
+
+  if (!isJsonObject(value)) {
+    pushIssue(issues, '$', 'IR must be an object');
+    return { ok: false, issues };
+  }
+
+  if (property(value, 'irVersion') !== GEORDI_IR_VERSION) {
+    pushIssue(issues, '$.irVersion', `IR version must be "${GEORDI_IR_VERSION}"`);
+  }
+
+  validateScene(property(value, 'scene'), issues);
+  validateNodes(property(value, 'nodes'), issues);
+  validateBindings(property(value, 'bindings'), issues);
+  validateAnimations(property(value, 'animations'), issues);
+
+  return { ok: issues.length === 0, issues };
+}
+
+function validateScene(value: JsonValue | undefined, issues: GeordiIrValidationIssue[]): void {
+  if (!isJsonObject(value)) {
+    pushIssue(issues, '$.scene', 'IR scene must be an object');
+    return;
+  }
+
+  requireString(value, 'id', '$.scene.id', issues);
+  requireFiniteNumber(value, 'width', '$.scene.width', issues);
+  requireFiniteNumber(value, 'height', '$.scene.height', issues);
+  optionalLiteral(value, 'units', 'px', '$.scene.units', issues);
+  optionalString(value, 'background', '$.scene.background', issues);
+}
+
+function validateNodes(value: JsonValue | undefined, issues: GeordiIrValidationIssue[]): void {
+  if (!isJsonArray(value)) {
+    pushIssue(issues, '$.nodes', 'IR nodes must be an array');
+    return;
+  }
+
+  for (let i = 0; i < value.length; i++) {
+    const path = `$.nodes[${i}]`;
+    const node = value[i];
+    if (!isJsonObject(node)) {
+      pushIssue(issues, path, 'IR node must be an object');
+      continue;
+    }
+
+    requireString(node, 'id', `${path}.id`, issues);
+    requireString(node, 'kind', `${path}.kind`, issues);
+    optionalString(node, 'parentId', `${path}.parentId`, issues);
+    optionalFiniteNumber(node, 'zIndex', `${path}.zIndex`, issues);
+    optionalBoolean(node, 'visible', `${path}.visible`, issues);
+    optionalBoolean(node, 'locked', `${path}.locked`, issues);
+
+    if (!isJsonObject(property(node, 'props'))) {
+      pushIssue(issues, `${path}.props`, 'IR node props must be an object');
+    }
+
+    const style = property(node, 'style');
+    if (style !== undefined && !isJsonObject(style)) {
+      pushIssue(issues, `${path}.style`, 'IR node style must be an object');
+    }
+  }
+}
+
+function validateBindings(value: JsonValue | undefined, issues: GeordiIrValidationIssue[]): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isJsonArray(value)) {
+    pushIssue(issues, '$.bindings', 'IR bindings must be an array when present');
+    return;
+  }
+
+  for (let i = 0; i < value.length; i++) {
+    const path = `$.bindings[${i}]`;
+    const binding = value[i];
+    if (!isJsonObject(binding)) {
+      pushIssue(issues, path, 'IR binding must be an object');
+      continue;
+    }
+
+    requireString(binding, 'id', `${path}.id`, issues);
+    requireString(binding, 'targetNodeId', `${path}.targetNodeId`, issues);
+    requireString(binding, 'targetProp', `${path}.targetProp`, issues);
+    requireString(binding, 'expression', `${path}.expression`, issues);
+    optionalString(binding, 'when', `${path}.when`, issues);
+  }
+}
+
+function validateAnimations(value: JsonValue | undefined, issues: GeordiIrValidationIssue[]): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isJsonArray(value)) {
+    pushIssue(issues, '$.animations', 'IR animations must be an array when present');
+    return;
+  }
+
+  for (let i = 0; i < value.length; i++) {
+    const path = `$.animations[${i}]`;
+    const animation = value[i];
+    if (!isJsonObject(animation)) {
+      pushIssue(issues, path, 'IR animation must be an object');
+      continue;
+    }
+
+    requireString(animation, 'id', `${path}.id`, issues);
+    requireString(animation, 'targetNodeId', `${path}.targetNodeId`, issues);
+    requireString(animation, 'property', `${path}.property`, issues);
+    optionalString(animation, 'easing', `${path}.easing`, issues);
+    optionalBoolean(animation, 'loop', `${path}.loop`, issues);
+    validateKeyframes(property(animation, 'keyframes'), `${path}.keyframes`, issues);
+  }
+}
+
+function validateKeyframes(
+  value: JsonValue | undefined,
+  path: string,
+  issues: GeordiIrValidationIssue[],
+): void {
+  if (!isJsonArray(value)) {
+    pushIssue(issues, path, 'IR animation keyframes must be an array');
+    return;
+  }
+
+  for (let i = 0; i < value.length; i++) {
+    const keyframePath = `${path}[${i}]`;
+    const keyframe = value[i];
+    if (!isJsonObject(keyframe)) {
+      pushIssue(issues, keyframePath, 'IR animation keyframe must be an object');
+      continue;
+    }
+
+    requireFiniteNumber(keyframe, 't', `${keyframePath}.t`, issues);
+    if (property(keyframe, 'value') === undefined) {
+      pushIssue(issues, `${keyframePath}.value`, 'IR animation keyframe value is required');
+    }
+  }
+}
+
+function requireString(
+  object: JsonObject,
+  key: string,
+  path: string,
+  issues: GeordiIrValidationIssue[],
+): void {
+  if (typeof object[key] !== 'string') {
+    pushIssue(issues, path, 'Value must be a string');
+  }
+}
+
+function optionalString(
+  object: JsonObject,
+  key: string,
+  path: string,
+  issues: GeordiIrValidationIssue[],
+): void {
+  if (object[key] !== undefined && typeof object[key] !== 'string') {
+    pushIssue(issues, path, 'Value must be a string when present');
+  }
+}
+
+function requireFiniteNumber(
+  object: JsonObject,
+  key: string,
+  path: string,
+  issues: GeordiIrValidationIssue[],
+): void {
+  if (!isFiniteNumber(object[key])) {
+    pushIssue(issues, path, 'Value must be a finite number');
+  }
+}
+
+function optionalFiniteNumber(
+  object: JsonObject,
+  key: string,
+  path: string,
+  issues: GeordiIrValidationIssue[],
+): void {
+  if (object[key] !== undefined && !isFiniteNumber(object[key])) {
+    pushIssue(issues, path, 'Value must be a finite number when present');
+  }
+}
+
+function optionalBoolean(
+  object: JsonObject,
+  key: string,
+  path: string,
+  issues: GeordiIrValidationIssue[],
+): void {
+  if (object[key] !== undefined && typeof object[key] !== 'boolean') {
+    pushIssue(issues, path, 'Value must be a boolean when present');
+  }
+}
+
+function optionalLiteral(
+  object: JsonObject,
+  key: string,
+  expected: string,
+  path: string,
+  issues: GeordiIrValidationIssue[],
+): void {
+  if (object[key] !== undefined && object[key] !== expected) {
+    pushIssue(issues, path, `Value must be "${expected}" when present`);
+  }
+}
+
+function isJsonObject(value: JsonValue | undefined): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isJsonArray(value: JsonValue | undefined): value is readonly JsonValue[] {
+  return Array.isArray(value);
+}
+
+function isFiniteNumber(value: JsonValue | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function property(object: JsonObject, key: string): JsonValue | undefined {
+  return object[key];
+}
+
+function pushIssue(
+  issues: GeordiIrValidationIssue[],
+  path: string,
+  message: string,
+): void {
+  issues.push({ path, message });
+}

--- a/packages/core/src/domain/models/index.ts
+++ b/packages/core/src/domain/models/index.ts
@@ -33,6 +33,10 @@ export type {
 export { isRectNode, isTextNode, isGroupNode, isImageNode } from './GeordiNode.js';
 
 export type {
+  JsonPrimitive,
+  JsonObject,
+  JsonArray,
+  JsonValue,
   GeordiVersion,
   Units,
   Origin,
@@ -45,3 +49,23 @@ export type {
 } from './GeordiScene.js';
 
 export { isGeordiScene } from './GeordiScene.js';
+
+export {
+  GEORDI_IR_VERSION,
+  GEORDI_IR_ARTIFACT_KEY,
+  GEORDI_IR_RECEIPT_KEY,
+  GEORDI_IR_HASH_ALGORITHM,
+  isGeordiIrV1,
+  validateGeordiIrV1,
+} from './GeordiIr.js';
+
+export type {
+  GeordiIrSceneV1,
+  GeordiIrNodeV1,
+  GeordiIrBindingV1,
+  GeordiIrKeyframeV1,
+  GeordiIrAnimationV1,
+  GeordiIrV1,
+  GeordiIrValidationIssue,
+  GeordiIrValidationResult,
+} from './GeordiIr.js';

--- a/packages/runtime-webgl/src/index.test.ts
+++ b/packages/runtime-webgl/src/index.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import type { GeordiScene } from '@flyingrobots/geordi-core';
+import type { GeordiIrV1, GeordiScene } from '@flyingrobots/geordi-core';
 import {
   GeordiCanvasContextUnavailableError,
   GeordiWebGLRenderer,
+  renderGeordiIrToCanvas,
   renderGeordiToCanvas,
 } from './index';
 
@@ -160,6 +161,48 @@ function makeScene(): GeordiScene {
   };
 }
 
+function makeIr(): GeordiIrV1 {
+  return {
+    irVersion: 'geordi-ir/1',
+    scene: {
+      id: 'scene:runtime-ir',
+      width: 100,
+      height: 50,
+      units: 'px',
+    },
+    nodes: [
+      {
+        id: 'rect-1',
+        kind: 'Rect',
+        props: {
+          x: 1,
+          y: 2,
+          width: 10,
+          height: 20,
+          fill: '#123456',
+        },
+      },
+      {
+        id: 'text-1',
+        kind: 'Text',
+        props: {
+          x: 5,
+          y: 6,
+          width: 80,
+          height: 12,
+          content: 'Hello',
+          color: '#ffffff',
+          fontFamily: 'Inter',
+          fontSize: 12,
+          fontWeight: 400,
+        },
+      },
+    ],
+    bindings: [],
+    animations: [],
+  };
+}
+
 describe('runtime-webgl public API', () => {
   it('exports renderer entrypoints', () => {
     expect(GeordiWebGLRenderer).toBeTypeOf('function');
@@ -172,6 +215,31 @@ describe('runtime-webgl public API', () => {
     installCanvasDocument(canvas);
 
     const rendered = renderGeordiToCanvas(makeScene());
+
+    expect(rendered).toBe(canvas);
+    expect(canvas.width).toBe(100);
+    expect(canvas.height).toBe(50);
+    expect(context.calls).toEqual([
+      { name: 'fillRect', args: [0, 0, 100, 50] },
+      { name: 'save', args: [] },
+      { name: 'beginPath', args: [] },
+      { name: 'rect', args: [1, 2, 10, 20] },
+      { name: 'closePath', args: [] },
+      { name: 'fill', args: [] },
+      { name: 'restore', args: [] },
+      { name: 'save', args: [] },
+      { name: 'fillText', args: ['Hello', 5, 6] },
+      { name: 'restore', args: [] },
+    ]);
+    expect(context.font).toBe('400 12px Inter');
+  });
+
+  it('renders geordi-ir/1 through the runtime preparation path', () => {
+    const context = new FakeCanvasContext2D();
+    const canvas = makeCanvas(context as object as CanvasRenderingContext2D);
+    installCanvasDocument(canvas);
+
+    const rendered = renderGeordiIrToCanvas(makeIr());
 
     expect(rendered).toBe(canvas);
     expect(canvas.width).toBe(100);

--- a/packages/runtime-webgl/src/index.ts
+++ b/packages/runtime-webgl/src/index.ts
@@ -5,4 +5,5 @@
  */
 
 export { GeordiCanvasContextUnavailableError, GeordiWebGLRenderer } from './WebGLRenderer.js';
-export { renderGeordiToCanvas } from './utils.js';
+export { GeordiRuntimeUnsupportedNodeKindError } from './prepareGeordiIr.js';
+export { renderGeordiIrToCanvas, renderGeordiToCanvas } from './utils.js';

--- a/packages/runtime-webgl/src/prepareGeordiIr.ts
+++ b/packages/runtime-webgl/src/prepareGeordiIr.ts
@@ -1,0 +1,201 @@
+import type {
+  Bounds,
+  GeordiIrNodeV1,
+  GeordiIrV1,
+  GeordiNode,
+  GeordiScene,
+  JsonObject,
+  NodeStyle,
+  PaintStyle,
+  SolidFill,
+  TextStyle,
+} from '@flyingrobots/geordi-core';
+
+export class GeordiRuntimeUnsupportedNodeKindError extends Error {
+  public readonly nodeKind: string;
+
+  constructor(nodeKind: string) {
+    super(`Unsupported runtime node kind: ${nodeKind}`);
+    this.name = new.target.name;
+    this.nodeKind = nodeKind;
+  }
+}
+
+export function prepareGeordiIr(ir: GeordiIrV1): GeordiScene {
+  return {
+    version: '0.1.0',
+    meta: {
+      generator: 'geordi-runtime-webgl',
+      source: ir.scene.id,
+      hash: ir.irVersion,
+    },
+    canvas: {
+      width: ir.scene.width,
+      height: ir.scene.height,
+      units: ir.scene.units ?? 'px',
+      origin: 'top-left',
+    },
+    nodes: ir.nodes.map((node) => prepareNode(node, childIdsFor(ir, node.id))),
+    tokens: {},
+  };
+}
+
+function prepareNode(node: GeordiIrNodeV1, children: readonly string[]): GeordiNode {
+  switch (node.kind) {
+    case 'Rect':
+      return {
+        id: node.id,
+        type: 'rect',
+        bounds: boundsFromProps(node.props),
+        style: styleFromProps(node.props),
+        static: true,
+      };
+
+    case 'Text':
+      return {
+        id: node.id,
+        type: 'text',
+        bounds: boundsFromProps(node.props),
+        style: textNodeStyleFromProps(node.props),
+        static: true,
+        content: stringProp(node.props, 'content', ''),
+      };
+
+    case 'Group':
+      return {
+        id: node.id,
+        type: 'group',
+        bounds: boundsFromProps(node.props),
+        style: styleFromProps(node.props),
+        static: true,
+        children,
+      };
+
+    case 'Image':
+      return {
+        id: node.id,
+        type: 'image',
+        bounds: boundsFromProps(node.props),
+        style: styleFromProps(node.props),
+        static: true,
+        src: stringProp(node.props, 'src', ''),
+      };
+
+    default:
+      throw new GeordiRuntimeUnsupportedNodeKindError(node.kind);
+  }
+}
+
+function childIdsFor(ir: GeordiIrV1, parentId: string): string[] {
+  return ir.nodes
+    .filter((node) => node.parentId === parentId)
+    .map((node) => node.id);
+}
+
+function boundsFromProps(props: JsonObject): Bounds {
+  return [
+    numberProp(props, 'x', 0),
+    numberProp(props, 'y', 0),
+    numberProp(props, 'width', 0),
+    numberProp(props, 'height', 0),
+  ];
+}
+
+function styleFromProps(props: JsonObject): NodeStyle {
+  const paint = paintStyleFromProps(props);
+  return paint ? { paint } : {};
+}
+
+function textNodeStyleFromProps(props: JsonObject): NodeStyle {
+  const paint = paintStyleFromProps(props);
+  const text = textStyleFromProps(props);
+  return paint ? { paint, text } : { text };
+}
+
+function paintStyleFromProps(props: JsonObject): PaintStyle | undefined {
+  const fill = solidFillFromString(optionalStringProp(props, 'fill'));
+  const stroke = solidFillFromString(optionalStringProp(props, 'stroke'));
+  const strokeWidth = optionalNumberProp(props, 'strokeWidth');
+  const opacity = optionalNumberProp(props, 'opacity');
+  const cornerRadius = optionalNumberProp(props, 'cornerRadius');
+
+  if (
+    fill === undefined &&
+    stroke === undefined &&
+    strokeWidth === undefined &&
+    opacity === undefined &&
+    cornerRadius === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(fill ? { fill } : {}),
+    ...(stroke ? { stroke } : {}),
+    ...(strokeWidth !== undefined ? { strokeWidth } : {}),
+    ...(opacity !== undefined ? { opacity } : {}),
+    ...(cornerRadius !== undefined ? { cornerRadius } : {}),
+  };
+}
+
+function textStyleFromProps(props: JsonObject): TextStyle {
+  const lineHeight = optionalNumberProp(props, 'lineHeight');
+  const align = textAlignFromProp(props);
+
+  return {
+    font: stringProp(props, 'fontFamily', 'sans-serif'),
+    size: numberProp(props, 'fontSize', 16),
+    weight: fontWeightFromProp(props),
+    color: stringProp(props, 'color', '#000000'),
+    ...(lineHeight !== undefined ? { lineHeight } : {}),
+    ...(align !== undefined ? { align } : {}),
+  };
+}
+
+function solidFillFromString(value: string | undefined): SolidFill | undefined {
+  return value === undefined ? undefined : { type: 'solid', color: value };
+}
+
+function fontWeightFromProp(props: JsonObject): number {
+  const value = propValue(props, 'fontWeight');
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (value === 'bold') {
+    return 700;
+  }
+
+  return 400;
+}
+
+function textAlignFromProp(props: JsonObject): 'left' | 'center' | 'right' | undefined {
+  const value = propValue(props, 'align');
+  if (value === 'left' || value === 'center' || value === 'right') {
+    return value;
+  }
+
+  return undefined;
+}
+
+function numberProp(props: JsonObject, key: string, fallback: number): number {
+  return optionalNumberProp(props, key) ?? fallback;
+}
+
+function optionalNumberProp(props: JsonObject, key: string): number | undefined {
+  const value = propValue(props, key);
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function stringProp(props: JsonObject, key: string, fallback: string): string {
+  return optionalStringProp(props, key) ?? fallback;
+}
+
+function optionalStringProp(props: JsonObject, key: string): string | undefined {
+  const value = propValue(props, key);
+  return typeof value === 'string' ? value : undefined;
+}
+
+function propValue(props: JsonObject, key: string) {
+  return props[key];
+}

--- a/packages/runtime-webgl/src/utils.ts
+++ b/packages/runtime-webgl/src/utils.ts
@@ -2,8 +2,9 @@
  * Utility functions for Geordi rendering
  */
 
-import type { GeordiScene } from '@flyingrobots/geordi-core';
+import type { GeordiIrV1, GeordiScene } from '@flyingrobots/geordi-core';
 import { GeordiWebGLRenderer } from './WebGLRenderer.js';
+import { prepareGeordiIr } from './prepareGeordiIr.js';
 
 /**
  * Render a Geordi scene to a canvas element
@@ -18,4 +19,8 @@ export function renderGeordiToCanvas(scene: GeordiScene): HTMLCanvasElement {
   );
 
   return renderer.render(scene);
+}
+
+export function renderGeordiIrToCanvas(ir: GeordiIrV1): HTMLCanvasElement {
+  return renderGeordiToCanvas(prepareGeordiIr(ir));
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,10 @@ importers:
         version: 4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1))
 
   packages/compiler-core:
+    dependencies:
+      '@flyingrobots/geordi-core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@types/node':
         specifier: ^25.9.1


### PR DESCRIPTION
## Summary

Implements the first five core IR runtime-contract slices:

- Move `geordi-ir/1` constants, structural types, and validation into `@flyingrobots/geordi-core`.
- Switch `@flyingrobots/geordi-compiler-core` to consume and re-export the core-owned IR contract.
- Add compiler-to-core contract coverage proving emitted IR parses through the canonical JSON port and validates under core.
- Add `@flyingrobots/geordi-runtime-webgl` preparation/rendering support for typed `GeordiIrV1` through `renderGeordiIrToCanvas()`.
- Update `BACKLOG.md`, `BEARING.md`, `CHANGELOG.md`, `docs/STATUS.md`, and `docs/V0_DESIGN_LAWS.md` so the current state is accurate: the legacy `GeordiScene` path still exists and remains a follow-up.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm test:docs`
- `pnpm test:package-names`
- `pnpm test:repo-sludge`
- `pnpm test:placeholders`
- `pnpm test:exports`
- `git diff --check`

## Notes

This does not retire the older public `GeordiScene` API yet. The next slice should make `geordi-ir/1` the preferred public runtime API and decide whether the old scene model is deprecated, renamed, or internalized before v0.1.
