### PR TITLE
[codex] Promote runtime IR contract

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -21,10 +21,11 @@ These open items come from the repo audit and the v0 design pass. See
 ### Make `geordi-ir/1` the runtime contract
 **Priority**: P0
 **Source**: v0 design laws, repo audit
-**Status**: In progress. Core now owns versioned `geordi-ir/1` types and structural validation,
-compiler-core emits/re-exports that shared contract, and runtime-webgl has a typed IR preparation
-and render path. The remaining release-blocker is retiring or explicitly deprecating the older
-public scene shape before v0.1.
+**Status**: Completed. Core owns versioned `geordi-ir/1` types and structural validation,
+compiler-core emits/re-exports that shared contract, runtime-webgl validates and renders
+`geordi-ir/1` through its primary API, and the old draw-ready scene shape is explicitly named
+`PreparedGeordiScene` for runtime internals. Compatibility aliases remain during the v0.1
+migration, but they are no longer the documented public renderer contract.
 
 `@flyingrobots/geordi-compiler-core` emits `geordi-ir/1`, while `@flyingrobots/geordi-core` and
 `@flyingrobots/geordi-runtime-webgl` still model/render an older `version`/`canvas`/`type`/`bounds`
@@ -87,6 +88,9 @@ historical context.
 - Package contract tests now exercise behavior: `wesley-generator` plans/generates artifacts from
   minimal SDL and fails with a custom error on bad SDL, while `runtime-webgl` renders the current
   scene contract against a canvas/context mock.
+- `geordi-ir/1` is the runtime contract: core owns IR validation, compiler-core emits the shared
+  contract, runtime-webgl validates IR at the boundary, fail-loud prop lowering rejects invalid
+  drawable props, and compiler output is rendered through the runtime contract in tests.
 
 ---
 

--- a/BEARING.md
+++ b/BEARING.md
@@ -33,12 +33,14 @@ Completed:
 - `@flyingrobots/geordi-core` owns versioned `geordi-ir/1` constants, types, and structural
   validation.
 - `@flyingrobots/geordi-compiler-core` emits/re-exports the shared core IR contract.
-- `@flyingrobots/geordi-runtime-webgl` can prepare and render typed `geordi-ir/1` through the
-  existing canvas renderer.
+- `@flyingrobots/geordi-runtime-webgl` validates and renders typed `geordi-ir/1` through
+  `renderGeordiToCanvas()`.
+- The draw-ready runtime scene shape is explicitly named `PreparedGeordiScene`; compatibility
+  aliases remain for the v0.1 migration, but `geordi-ir/1` is the documented renderer contract.
+- Compiler-emitted IR is covered end to end through runtime rendering.
 
 Still true:
 
-- `runtime-webgl` still exposes the older `GeordiScene` rendering path during migration.
 - The graphics numeric profile is only partially defined. JSON is deterministic, but geometry,
   vectors, matrices, transforms, and runtime capability declaration are not fully specified.
 
@@ -48,14 +50,14 @@ Still true:
    - GitHub Actions Dependabot PR #10 was mergeable and has been merged.
    - Conflicting npm Dependabot PR #8 should be recreated by Dependabot before any manual lockfile
      work.
-2. Finish the runtime-contract migration by making the public renderer API prefer `geordi-ir/1`
-   and by deprecating, renaming, or internalizing the legacy scene shape.
-3. Keep the graphics numeric profile explicit while migrating runtime-facing types.
+2. Define and enforce the graphics numeric profile.
+3. Move the canonical JSON port into core so IR validation, deterministic JSON, and numeric law
+   share the same package boundary.
 
 ## Recommended P0 Order
 
-1. Finish making `geordi-ir/1` the public runtime contract.
-2. Define and enforce the graphics numeric profile.
+1. Define and enforce the graphics numeric profile.
+2. Move canonical JSON ownership into `@flyingrobots/geordi-core`.
 
 ## Dependency Work
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
 - **`@flyingrobots/geordi-runtime-webgl`**: Add a typed `geordi-ir/1` preparation path plus
   `renderGeordiIrToCanvas()` so runtime callers can render core-owned IR through the existing
   canvas renderer while legacy scene rendering remains available during migration.
+- **`@flyingrobots/geordi-runtime-webgl`**: Promote `renderGeordiToCanvas()` to the primary
+  public `geordi-ir/1` rendering API, add `renderPreparedSceneToCanvas()` for the draw-ready
+  runtime scene shape, and retain `renderGeordiIrToCanvas()` as a compatibility alias.
+- **`@flyingrobots/geordi-core`**: Rename the draw-ready scene model at the type level with
+  `PreparedGeordiScene` and `PreparedGeordiNode` aliases so the public contract is no longer
+  confused with `geordi-ir/1`.
 - **`@flyingrobots/geordi-compiler-core`**: Semantic validation engine — `validateCanonicalAst()` with two-tier rule registry; Tier 1 (structural: `sceneDimensions`, `nodeKindValid`, `duplicateId`, `danglingRef`, `cycleDetection`) gates Tier 2 (semantic: `requiredProps` per NodeKind); iterative Kahn's cycle detection passes 10k-node chains without stack overflow
 - **`@flyingrobots/geordi-compiler-core`**: Deterministic IR emitter — `emitGeordiIrArtifact()` replaces stub; two-phase topological sort (Kahn's on `parentId` DAG, tie-broken `zIndex ASC → kind ASC → id ASC` bytewise); strips `sourceRef` and `__typename`
 - **`@flyingrobots/geordi-compiler-core`**: Determinism certificate — `emitReceiptArtifact()` emits `scene.geordi.json.receipt` alongside IR containing `comparatorVersion`, `inputHash` (SHA-256 of `input.source`), `irHash` (SHA-256 of the emitted IR), `irHashAlg` (`"sha256"`), `irVersion`, and `rulesetFingerprint` (SHA-256 of sorted rule IDs)
@@ -43,8 +49,11 @@
   IR parses through the canonical JSON port and validates under the core-owned IR contract.
 - **`@flyingrobots/geordi-runtime-webgl`**: add coverage for rendering `geordi-ir/1` through the
   new runtime preparation path.
+- **`@flyingrobots/geordi-runtime-webgl`**: add runtime-bound IR validation, fail-loud prop
+  lowering, and compiler-to-runtime contract coverage that compiles canonical AST JSON, parses
+  emitted IR through the canonical JSON port, validates it as `geordi-ir/1`, and renders it.
 - **`@flyingrobots/geordi-wesley-generator`**: add behavior contract tests for `plan()`, successful SDL-to-artifacts generation, and custom failure errors on bad SDL
-- **`@flyingrobots/geordi-runtime-webgl`**: add canvas/context mock behavior tests for rendering the current scene contract and context-unavailable failure
+- **`@flyingrobots/geordi-runtime-webgl`**: add canvas/context mock behavior tests for rendering the prepared scene contract and context-unavailable failure
 - **`@flyingrobots/geordi-compiler-core`**: 74 new tests across sprint 3 — first batch: `stableStringify` (22), `parseInput` table-driven (9), `determinism` (3) → 36 tests; second batch: `validateAst` (15), `emitTypes` (19), `determinism` +4, `compile.golden` +3 → total 79 tests
 - **`@flyingrobots/geordi-schema-graphql`**: 42 new tests — `extractScene` (10), `extractNodes` (10), `toCanonicalAst` (14), `e2e.terminal` (8)
 - Cycle detection verifies Tier 2 is suppressed when Tier 1 errors present
@@ -74,6 +83,9 @@
 - `parseGraphql`: SDL wrapped in `Source(sdl, filename)` so the returned `DocumentNode` carries filename metadata through to downstream diagnostics
 - `test/determinism`: shuffle fixture aligned with `BASE_INPUT` — added `visible: true` to all nodes and `units: 'px'` to scene
 - `docs/ERROR_CODES.md`: corrected `Rect` required props example — only `width` and `height` are required; `x` and `y` are optional
+- `runtime-webgl`: runtime rendering now validates IR before preparing draw-ready scenes and
+  throws custom runtime errors for invalid IR, unsupported node kinds, and invalid required node
+  props instead of silently falling back to invisible geometry or empty content.
 
 - Invalid JSON input no longer emits `GEORDI_E_INTERNAL_INVARIANT`; now correctly emits `GEORDI_E_INPUT_INVALID_JSON`
 - Invalid GraphQL SDL input now emits `GEORDI_E_INPUT_INVALID_SDL` instead of `GEORDI_E_INTERNAL_INVARIANT`

--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ All Geordi runtimes implement a shared contract:
 
 ```ts
 interface GeordiRuntime {
-  load(scene: GeordiScene): Promise<void>;
+  load(ir: GeordiIrV1): Promise<void>;
   render(): void;
-  updateNode(id: string, updates: Partial<GeordiNode>): void;
+  updateNode(id: string, props: JsonObject): void;
   hitTest(x: number, y: number): HitResult | null;
   dispose(): void;
 }

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -48,9 +48,9 @@ Wesley GeneratorPlugin adapter scaffold.
 
 Core domain package.
 
-- Current domain models and guards for the older scene shape.
 - Versioned `geordi-ir/1` constants, structural types, and validation.
-- Still needs the older scene shape deprecated, renamed, or internalized before v0.1.
+- Draw-ready runtime scene aliases named `PreparedGeordiScene` and `PreparedGeordiNode`.
+- Compatibility aliases for the older scene names remain during the v0.1 migration.
 
 #### `@flyingrobots/geordi-runtime-webgl`
 
@@ -58,8 +58,10 @@ Canvas-backed WebGL-runtime scaffold.
 
 - Basic renderer implementation.
 - Public entrypoint contract test.
-- Typed `geordi-ir/1` preparation path and `renderGeordiIrToCanvas()` adapter.
-- Still exposes the older `GeordiScene` path during migration.
+- `renderGeordiToCanvas()` is the primary public `geordi-ir/1` rendering API.
+- `renderPreparedSceneToCanvas()` renders draw-ready runtime scenes explicitly.
+- Runtime-bound IR validation and fail-loud prop lowering use custom runtime error types.
+- Compiler-emitted IR is rendered through the runtime contract in an integration test.
 
 ## Infrastructure
 
@@ -83,10 +85,10 @@ Latest full local gate during the core IR runtime-contract work:
 | --- | ---: | --- |
 | `@flyingrobots/geordi-compiler-core` | 73 | Green |
 | `@flyingrobots/geordi-schema-graphql` | 51 | Green |
-| `@flyingrobots/geordi-core` | 11 | Green |
-| `@flyingrobots/geordi-runtime-webgl` | 4 | Green |
+| `@flyingrobots/geordi-core` | 12 | Green |
+| `@flyingrobots/geordi-runtime-webgl` | 9 | Green |
 | `@flyingrobots/geordi-wesley-generator` | 3 | Green |
-| **Total package tests** | **142** | Green |
+| **Total package tests** | **148** | Green |
 
 Additional gates:
 
@@ -105,17 +107,14 @@ Immediate:
 1. Keep dependency hygiene clean.
    - GitHub Actions Dependabot update PR #10 has been merged.
    - npm/yarn Dependabot PR #8 was stale and conflicting; Dependabot has been asked to recreate it.
-2. Make the runtime public API prefer `geordi-ir/1` and decide the deprecation/internalization path
-   for the older `GeordiScene` model.
-3. Define the validator failure surface for runtime-bound IR: caller-validated only, or explicit
-   runtime validation with custom runtime error types.
+2. Move the canonical JSON port into `@flyingrobots/geordi-core`.
+3. Define the graphics numeric profile for geometry, vectors, matrices, transforms, and runtime
+   capability requirements.
 
 Short term:
 
-4. Define the graphics numeric profile for geometry, vectors, matrices, transforms, and runtime
-   capability requirements.
-5. Add source maps and diagnostic UX improvements.
-6. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
+4. Add source maps and diagnostic UX improvements.
+5. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
 
 ## Decision Log
 

--- a/docs/V0_DESIGN_LAWS.md
+++ b/docs/V0_DESIGN_LAWS.md
@@ -433,10 +433,11 @@ Add a root flat ESLint config or downgrade intentionally. CI currently runs lint
 
 Move versioned IR types and validation into `@flyingrobots/geordi-core`. Update `runtime-webgl` to accept validated IR directly or expose only an internal preparation step.
 
-**Status**: In progress. `@flyingrobots/geordi-core` now owns `geordi-ir/1` constants, types,
-and structural validation. `compiler-core` emits/re-exports the shared contract, and
-`runtime-webgl` has a typed IR preparation/render path. The older public `GeordiScene` shape still
-needs to be deprecated, renamed, or internalized before v0.1.
+**Status**: Completed. `@flyingrobots/geordi-core` owns `geordi-ir/1` constants, types, and
+structural validation. `compiler-core` emits/re-exports the shared contract. `runtime-webgl`
+validates IR at the boundary, renders it through the primary `renderGeordiToCanvas()` API, and
+names the draw-ready runtime shape `PreparedGeordiScene`. Compatibility aliases remain during the
+v0.1 migration, but they are no longer the documented public renderer contract.
 
 ### P0: Implement or remove canonicalization
 
@@ -507,5 +508,5 @@ The first stabilization pass is merged. Continue in this order:
 2. Validate GraphQL directive argument types at runtime.
 3. Lower or explicitly reject every known Geordi directive.
 4. Expand package behavior tests beyond public entrypoint smoke.
-5. Move `geordi-ir/1` into `@flyingrobots/geordi-core` as the runtime contract.
-6. Define and enforce the graphics numeric profile.
+5. Define and enforce the graphics numeric profile.
+6. Move canonical JSON ownership into `@flyingrobots/geordi-core`.

--- a/packages/core/src/domain/models/GeordiIr.test.ts
+++ b/packages/core/src/domain/models/GeordiIr.test.ts
@@ -75,6 +75,23 @@ describe('Geordi IR v1 contract', () => {
     ]);
   });
 
+  it('rejects non-positive scene dimensions', () => {
+    const result = validateGeordiIrV1({
+      ...VALID_IR,
+      scene: {
+        id: 'scene:test',
+        width: 0,
+        height: -1,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.map((issue) => issue.path)).toEqual([
+      '$.scene.width',
+      '$.scene.height',
+    ]);
+  });
+
   it('rejects nodes without object props', () => {
     const result = validateGeordiIrV1({
       ...VALID_IR,

--- a/packages/core/src/domain/models/GeordiIr.ts
+++ b/packages/core/src/domain/models/GeordiIr.ts
@@ -95,8 +95,8 @@ function validateScene(value: JsonValue | undefined, issues: GeordiIrValidationI
   }
 
   requireString(value, 'id', '$.scene.id', issues);
-  requireFiniteNumber(value, 'width', '$.scene.width', issues);
-  requireFiniteNumber(value, 'height', '$.scene.height', issues);
+  requirePositiveFiniteNumber(value, 'width', '$.scene.width', issues);
+  requirePositiveFiniteNumber(value, 'height', '$.scene.height', issues);
   optionalLiteral(value, 'units', 'px', '$.scene.units', issues);
   optionalString(value, 'background', '$.scene.background', issues);
 }
@@ -241,6 +241,18 @@ function requireFiniteNumber(
 ): void {
   if (!isFiniteNumber(object[key])) {
     pushIssue(issues, path, 'Value must be a finite number');
+  }
+}
+
+function requirePositiveFiniteNumber(
+  object: JsonObject,
+  key: string,
+  path: string,
+  issues: GeordiIrValidationIssue[],
+): void {
+  const value = property(object, key);
+  if (!isFiniteNumber(value) || value <= 0) {
+    pushIssue(issues, path, 'Value must be a positive finite number');
   }
 }
 

--- a/packages/core/src/domain/models/GeordiNode.ts
+++ b/packages/core/src/domain/models/GeordiNode.ts
@@ -136,8 +136,11 @@ export interface ImageNode extends GeordiNodeBase {
   readonly src: string;
 }
 
-/** Union type of all node types */
+/** Union type of all prepared runtime node types */
 export type GeordiNode = RectNode | TextNode | GroupNode | ImageNode;
+
+/** Draw-ready node produced by a runtime preparation step. */
+export type PreparedGeordiNode = GeordiNode;
 
 /** Type guard for rect nodes */
 export function isRectNode(node: GeordiNode): node is RectNode {

--- a/packages/core/src/domain/models/GeordiScene.test.ts
+++ b/packages/core/src/domain/models/GeordiScene.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
 
-import type { GeordiScene } from './GeordiScene.js';
+import type { PreparedGeordiScene } from './GeordiScene.js';
 
-describe('GeordiScene', (): void => {
-  it('should create a valid scene with metadata', (): void => {
-    const scene: GeordiScene = {
+describe('PreparedGeordiScene', (): void => {
+  it('should create a valid prepared scene with metadata', (): void => {
+    const scene: PreparedGeordiScene = {
       version: '0.1.0',
       meta: {
         generator: '@flyingrobots/geordi-vue',
@@ -27,7 +27,7 @@ describe('GeordiScene', (): void => {
   });
 
   it('should contain nodes with proper references', (): void => {
-    const scene: GeordiScene = {
+    const scene: PreparedGeordiScene = {
       version: '0.1.0',
       meta: {
         generator: '@flyingrobots/geordi-core',
@@ -81,7 +81,7 @@ describe('GeordiScene', (): void => {
   });
 
   it('should have interaction hit regions', (): void => {
-    const scene: GeordiScene = {
+    const scene: PreparedGeordiScene = {
       version: '0.1.0',
       meta: {
         generator: '@flyingrobots/geordi-core',

--- a/packages/core/src/domain/models/GeordiScene.ts
+++ b/packages/core/src/domain/models/GeordiScene.ts
@@ -4,7 +4,7 @@
  * Root scene graph structure.
  */
 
-import type { Bounds, GeordiNode } from './GeordiNode.js';
+import type { Bounds, PreparedGeordiNode } from './GeordiNode.js';
 
 /** Scene version */
 export type GeordiVersion = '0.1.0';
@@ -71,8 +71,8 @@ export interface GeordiInteraction {
   readonly hitRegions: readonly HitRegion[];
 }
 
-/** Complete Geordi scene */
-export interface GeordiScene {
+/** Draw-ready scene produced by a runtime preparation step. */
+export interface PreparedGeordiScene {
   /** Scene format version */
   readonly version: GeordiVersion;
 
@@ -83,7 +83,7 @@ export interface GeordiScene {
   readonly canvas: GeordiCanvas;
 
   /** Scene nodes */
-  readonly nodes: readonly GeordiNode[];
+  readonly nodes: readonly PreparedGeordiNode[];
 
   /** Design tokens */
   readonly tokens: GeordiTokens;
@@ -95,13 +95,21 @@ export interface GeordiScene {
   readonly diagnostics?: readonly string[];
 }
 
-/** Type guard for Geordi scene */
-export function isGeordiScene(value: object | null): value is GeordiScene {
+/**
+ * Complete Geordi scene.
+ *
+ * Compatibility alias retained during the v0.1 migration. `geordi-ir/1` is the
+ * public scene contract; use `PreparedGeordiScene` for draw-ready runtime internals.
+ */
+export type GeordiScene = PreparedGeordiScene;
+
+/** Type guard for prepared runtime scenes. */
+export function isPreparedGeordiScene(value: object | null): value is PreparedGeordiScene {
   if (typeof value !== 'object' || value === null) {
     return false;
   }
 
-  const scene = value as Readonly<Partial<Record<keyof GeordiScene, JsonValue>>>;
+  const scene = value as Readonly<Partial<Record<keyof PreparedGeordiScene, JsonValue>>>;
 
   return (
     typeof scene.version === 'string' &&
@@ -117,3 +125,10 @@ export function isGeordiScene(value: object | null): value is GeordiScene {
     !Array.isArray(scene.tokens)
   );
 }
+
+/**
+ * Type guard for Geordi scene.
+ *
+ * Compatibility alias retained during the v0.1 migration. Use `isPreparedGeordiScene`.
+ */
+export const isGeordiScene = isPreparedGeordiScene;

--- a/packages/core/src/domain/models/index.ts
+++ b/packages/core/src/domain/models/index.ts
@@ -28,6 +28,7 @@ export type {
   GroupNode,
   ImageNode,
   GeordiNode,
+  PreparedGeordiNode,
 } from './GeordiNode.js';
 
 export { isRectNode, isTextNode, isGroupNode, isImageNode } from './GeordiNode.js';
@@ -45,10 +46,11 @@ export type {
   GeordiTokens,
   HitRegion,
   GeordiInteraction,
+  PreparedGeordiScene,
   GeordiScene,
 } from './GeordiScene.js';
 
-export { isGeordiScene } from './GeordiScene.js';
+export { isPreparedGeordiScene, isGeordiScene } from './GeordiScene.js';
 
 export {
   GEORDI_IR_VERSION,

--- a/packages/runtime-webgl/package.json
+++ b/packages/runtime-webgl/package.json
@@ -27,6 +27,7 @@
     "@flyingrobots/geordi-core": "workspace:*"
   },
   "devDependencies": {
+    "@flyingrobots/geordi-compiler-core": "workspace:*",
     "@types/node": "^25.9.1",
     "@typescript-eslint/eslint-plugin": "^8.59.4",
     "@typescript-eslint/parser": "^8.59.4",

--- a/packages/runtime-webgl/src/WebGLRenderer.ts
+++ b/packages/runtime-webgl/src/WebGLRenderer.ts
@@ -6,8 +6,8 @@
  */
 
 import type {
-  GeordiScene,
   GeordiNode,
+  PreparedGeordiScene,
   RectNode,
   TextNode,
 } from '@flyingrobots/geordi-core';
@@ -42,9 +42,9 @@ export class GeordiWebGLRenderer {
   }
 
   /**
-   * Render a complete Geordi scene to the canvas
+   * Render a prepared runtime scene to the canvas
    */
-  render(scene: GeordiScene): HTMLCanvasElement {
+  renderPreparedScene(scene: PreparedGeordiScene): HTMLCanvasElement {
     // Clear canvas
     this.ctx.fillStyle = '#000000';
     this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
@@ -55,6 +55,15 @@ export class GeordiWebGLRenderer {
     }
 
     return this.canvas;
+  }
+
+  /**
+   * Render a prepared runtime scene to the canvas.
+   *
+   * @deprecated Use `renderPreparedScene`.
+   */
+  render(scene: PreparedGeordiScene): HTMLCanvasElement {
+    return this.renderPreparedScene(scene);
   }
 
   /**

--- a/packages/runtime-webgl/src/index.test.ts
+++ b/packages/runtime-webgl/src/index.test.ts
@@ -1,9 +1,21 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import type { GeordiIrV1, GeordiScene } from '@flyingrobots/geordi-core';
+import {
+  isGeordiIrV1,
+  type GeordiIrV1,
+  type PreparedGeordiScene,
+} from '@flyingrobots/geordi-core';
+import {
+  compile,
+  parseJsonValue,
+  stringifyCanonicalJson,
+} from '@flyingrobots/geordi-compiler-core';
 import {
   GeordiCanvasContextUnavailableError,
+  GeordiRuntimeInvalidIrError,
+  GeordiRuntimeInvalidNodePropsError,
   GeordiWebGLRenderer,
   renderGeordiIrToCanvas,
+  renderPreparedSceneToCanvas,
   renderGeordiToCanvas,
 } from './index';
 
@@ -75,6 +87,13 @@ class FakeCanvasContext2D {
   }
 }
 
+class RuntimeContractTestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = new.target.name;
+  }
+}
+
 const hadDocument = Object.prototype.hasOwnProperty.call(globalThis, 'document');
 const originalDocument = hadDocument ? globalThis.document : undefined;
 
@@ -112,7 +131,7 @@ function installCanvasDocument(canvas: HTMLCanvasElement): void {
   });
 }
 
-function makeScene(): GeordiScene {
+function makePreparedScene(): PreparedGeordiScene {
   return {
     version: '0.1.0',
     meta: {
@@ -207,14 +226,15 @@ describe('runtime-webgl public API', () => {
   it('exports renderer entrypoints', () => {
     expect(GeordiWebGLRenderer).toBeTypeOf('function');
     expect(renderGeordiToCanvas).toBeTypeOf('function');
+    expect(renderPreparedSceneToCanvas).toBeTypeOf('function');
   });
 
-  it('renders the current scene contract to a canvas context', () => {
+  it('renders prepared scenes to a canvas context', () => {
     const context = new FakeCanvasContext2D();
     const canvas = makeCanvas(context as object as CanvasRenderingContext2D);
     installCanvasDocument(canvas);
 
-    const rendered = renderGeordiToCanvas(makeScene());
+    const rendered = renderPreparedSceneToCanvas(makePreparedScene());
 
     expect(rendered).toBe(canvas);
     expect(canvas.width).toBe(100);
@@ -234,12 +254,12 @@ describe('runtime-webgl public API', () => {
     expect(context.font).toBe('400 12px Inter');
   });
 
-  it('renders geordi-ir/1 through the runtime preparation path', () => {
+  it('renders geordi-ir/1 through the primary runtime API', () => {
     const context = new FakeCanvasContext2D();
     const canvas = makeCanvas(context as object as CanvasRenderingContext2D);
     installCanvasDocument(canvas);
 
-    const rendered = renderGeordiIrToCanvas(makeIr());
+    const rendered = renderGeordiToCanvas(makeIr());
 
     expect(rendered).toBe(canvas);
     expect(canvas.width).toBe(100);
@@ -257,6 +277,61 @@ describe('runtime-webgl public API', () => {
       { name: 'restore', args: [] },
     ]);
     expect(context.font).toBe('400 12px Inter');
+  });
+
+  it('keeps the deprecated IR helper as a compatibility alias', () => {
+    expect(renderGeordiIrToCanvas).toBe(renderGeordiToCanvas);
+  });
+
+  it('throws a custom error when runtime IR validation fails', () => {
+    const invalidIr = {
+      ...makeIr(),
+      scene: {
+        id: 'scene:runtime-ir',
+        width: 0,
+        height: 50,
+      },
+    } as object as GeordiIrV1;
+
+    expect(() => renderGeordiToCanvas(invalidIr)).toThrow(GeordiRuntimeInvalidIrError);
+  });
+
+  it('throws a custom error when required runtime node props are missing', () => {
+    const invalidIr: GeordiIrV1 = {
+      ...makeIr(),
+      nodes: [
+        {
+          id: 'rect-1',
+          kind: 'Rect',
+          props: {
+            height: 20,
+          },
+        },
+      ],
+    };
+
+    expect(() => renderGeordiToCanvas(invalidIr)).toThrow(
+      GeordiRuntimeInvalidNodePropsError,
+    );
+  });
+
+  it('throws a custom error when required string props are invalid', () => {
+    const invalidIr: GeordiIrV1 = {
+      ...makeIr(),
+      nodes: [
+        {
+          id: 'image-1',
+          kind: 'Image',
+          props: {
+            src: null,
+          },
+        },
+      ],
+    };
+
+    expect(() => renderGeordiToCanvas(invalidIr)).toThrow(
+      GeordiRuntimeInvalidNodePropsError,
+    );
   });
 
   it('throws a custom error when a canvas context cannot be created', () => {
@@ -265,5 +340,91 @@ describe('runtime-webgl public API', () => {
     expect(() => new GeordiWebGLRenderer(10, 10)).toThrow(
       GeordiCanvasContextUnavailableError,
     );
+  });
+
+  it('renders compiler-emitted geordi-ir/1 through the runtime contract', async () => {
+    const source = stringifyCanonicalJson({
+      kind: 'Scene',
+      astVersion: '1',
+      scene: {
+        id: 'scene:compiler-runtime',
+        width: 120,
+        height: 80,
+        units: 'px',
+      },
+      nodes: [
+        {
+          id: 'rect-1',
+          kind: 'Rect',
+          props: {
+            x: 4,
+            y: 5,
+            width: 20,
+            height: 30,
+            fill: '#123456',
+          },
+          visible: true,
+        },
+        {
+          id: 'text-1',
+          kind: 'Text',
+          props: {
+            x: 7,
+            y: 8,
+            content: 'Compiled',
+            color: '#ffffff',
+            fontFamily: 'Inter',
+            fontSize: 14,
+          },
+          visible: true,
+        },
+      ],
+      metadata: { sourceFormat: 'canonical-ast-json' },
+    });
+
+    const result = await compile({
+      format: 'canonical-ast-json',
+      source,
+      options: {
+        target: 'geordi-ir-v1',
+        emit: {
+          irJson: true,
+          tsTypes: false,
+        },
+        canonicalize: true,
+      },
+    });
+
+    if (!result.ok) {
+      throw new RuntimeContractTestError('Compile failed');
+    }
+
+    const artifact = result.artifacts['scene.geordi.json'];
+    const ir = parseJsonValue(String(artifact.content));
+    if (!isGeordiIrV1(ir)) {
+      throw new RuntimeContractTestError('Invalid IR artifact');
+    }
+
+    const context = new FakeCanvasContext2D();
+    const canvas = makeCanvas(context as object as CanvasRenderingContext2D);
+    installCanvasDocument(canvas);
+
+    const rendered = renderGeordiToCanvas(ir);
+
+    expect(rendered).toBe(canvas);
+    expect(canvas.width).toBe(120);
+    expect(canvas.height).toBe(80);
+    expect(context.calls).toEqual([
+      { name: 'fillRect', args: [0, 0, 120, 80] },
+      { name: 'save', args: [] },
+      { name: 'beginPath', args: [] },
+      { name: 'rect', args: [4, 5, 20, 30] },
+      { name: 'closePath', args: [] },
+      { name: 'fill', args: [] },
+      { name: 'restore', args: [] },
+      { name: 'save', args: [] },
+      { name: 'fillText', args: ['Compiled', 7, 8] },
+      { name: 'restore', args: [] },
+    ]);
   });
 });

--- a/packages/runtime-webgl/src/index.ts
+++ b/packages/runtime-webgl/src/index.ts
@@ -5,5 +5,13 @@
  */
 
 export { GeordiCanvasContextUnavailableError, GeordiWebGLRenderer } from './WebGLRenderer.js';
-export { GeordiRuntimeUnsupportedNodeKindError } from './prepareGeordiIr.js';
-export { renderGeordiIrToCanvas, renderGeordiToCanvas } from './utils.js';
+export {
+  GeordiRuntimeInvalidIrError,
+  GeordiRuntimeInvalidNodePropsError,
+  GeordiRuntimeUnsupportedNodeKindError,
+} from './prepareGeordiIr.js';
+export {
+  renderGeordiIrToCanvas,
+  renderGeordiToCanvas,
+  renderPreparedSceneToCanvas,
+} from './utils.js';

--- a/packages/runtime-webgl/src/prepareGeordiIr.ts
+++ b/packages/runtime-webgl/src/prepareGeordiIr.ts
@@ -1,15 +1,28 @@
+import { validateGeordiIrV1 } from '@flyingrobots/geordi-core';
 import type {
   Bounds,
   GeordiIrNodeV1,
   GeordiIrV1,
-  GeordiNode,
-  GeordiScene,
+  GeordiIrValidationIssue,
   JsonObject,
+  JsonValue,
   NodeStyle,
   PaintStyle,
+  PreparedGeordiNode,
+  PreparedGeordiScene,
   SolidFill,
   TextStyle,
 } from '@flyingrobots/geordi-core';
+
+export class GeordiRuntimeInvalidIrError extends Error {
+  public readonly issues: readonly GeordiIrValidationIssue[];
+
+  constructor(issues: readonly GeordiIrValidationIssue[]) {
+    super('Invalid Geordi IR');
+    this.name = new.target.name;
+    this.issues = issues;
+  }
+}
 
 export class GeordiRuntimeUnsupportedNodeKindError extends Error {
   public readonly nodeKind: string;
@@ -21,7 +34,26 @@ export class GeordiRuntimeUnsupportedNodeKindError extends Error {
   }
 }
 
-export function prepareGeordiIr(ir: GeordiIrV1): GeordiScene {
+export class GeordiRuntimeInvalidNodePropsError extends Error {
+  public readonly nodeId: string;
+  public readonly prop: string;
+  public readonly expected: string;
+
+  constructor(nodeId: string, prop: string, expected: string) {
+    super('Invalid runtime node props');
+    this.name = new.target.name;
+    this.nodeId = nodeId;
+    this.prop = prop;
+    this.expected = expected;
+  }
+}
+
+export function prepareGeordiIr(ir: GeordiIrV1): PreparedGeordiScene {
+  const result = validateGeordiIrV1(ir);
+  if (!result.ok) {
+    throw new GeordiRuntimeInvalidIrError(result.issues);
+  }
+
   return {
     version: '0.1.0',
     meta: {
@@ -40,14 +72,14 @@ export function prepareGeordiIr(ir: GeordiIrV1): GeordiScene {
   };
 }
 
-function prepareNode(node: GeordiIrNodeV1, children: readonly string[]): GeordiNode {
+function prepareNode(node: GeordiIrNodeV1, children: readonly string[]): PreparedGeordiNode {
   switch (node.kind) {
     case 'Rect':
       return {
         id: node.id,
         type: 'rect',
-        bounds: boundsFromProps(node.props),
-        style: styleFromProps(node.props),
+        bounds: boundsFromNode(node, true),
+        style: styleFromNode(node),
         static: true,
       };
 
@@ -55,18 +87,18 @@ function prepareNode(node: GeordiIrNodeV1, children: readonly string[]): GeordiN
       return {
         id: node.id,
         type: 'text',
-        bounds: boundsFromProps(node.props),
-        style: textNodeStyleFromProps(node.props),
+        bounds: boundsFromNode(node, false),
+        style: textNodeStyleFromNode(node),
         static: true,
-        content: stringProp(node.props, 'content', ''),
+        content: requiredStringProp(node, 'content'),
       };
 
     case 'Group':
       return {
         id: node.id,
         type: 'group',
-        bounds: boundsFromProps(node.props),
-        style: styleFromProps(node.props),
+        bounds: boundsFromNode(node, false),
+        style: styleFromNode(node),
         static: true,
         children,
       };
@@ -75,10 +107,10 @@ function prepareNode(node: GeordiIrNodeV1, children: readonly string[]): GeordiN
       return {
         id: node.id,
         type: 'image',
-        bounds: boundsFromProps(node.props),
-        style: styleFromProps(node.props),
+        bounds: boundsFromNode(node, false),
+        style: styleFromNode(node),
         static: true,
-        src: stringProp(node.props, 'src', ''),
+        src: requiredStringProp(node, 'src'),
       };
 
     default:
@@ -92,32 +124,32 @@ function childIdsFor(ir: GeordiIrV1, parentId: string): string[] {
     .map((node) => node.id);
 }
 
-function boundsFromProps(props: JsonObject): Bounds {
+function boundsFromNode(node: GeordiIrNodeV1, requireSize: boolean): Bounds {
   return [
-    numberProp(props, 'x', 0),
-    numberProp(props, 'y', 0),
-    numberProp(props, 'width', 0),
-    numberProp(props, 'height', 0),
+    optionalNumberProp(node, 'x') ?? 0,
+    optionalNumberProp(node, 'y') ?? 0,
+    requireSize ? requiredNumberProp(node, 'width') : optionalNumberProp(node, 'width') ?? 0,
+    requireSize ? requiredNumberProp(node, 'height') : optionalNumberProp(node, 'height') ?? 0,
   ];
 }
 
-function styleFromProps(props: JsonObject): NodeStyle {
-  const paint = paintStyleFromProps(props);
+function styleFromNode(node: GeordiIrNodeV1): NodeStyle {
+  const paint = paintStyleFromNode(node);
   return paint ? { paint } : {};
 }
 
-function textNodeStyleFromProps(props: JsonObject): NodeStyle {
-  const paint = paintStyleFromProps(props);
-  const text = textStyleFromProps(props);
+function textNodeStyleFromNode(node: GeordiIrNodeV1): NodeStyle {
+  const paint = paintStyleFromNode(node);
+  const text = textStyleFromNode(node);
   return paint ? { paint, text } : { text };
 }
 
-function paintStyleFromProps(props: JsonObject): PaintStyle | undefined {
-  const fill = solidFillFromString(optionalStringProp(props, 'fill'));
-  const stroke = solidFillFromString(optionalStringProp(props, 'stroke'));
-  const strokeWidth = optionalNumberProp(props, 'strokeWidth');
-  const opacity = optionalNumberProp(props, 'opacity');
-  const cornerRadius = optionalNumberProp(props, 'cornerRadius');
+function paintStyleFromNode(node: GeordiIrNodeV1): PaintStyle | undefined {
+  const fill = solidFillFromString(optionalStringProp(node, 'fill'));
+  const stroke = solidFillFromString(optionalStringProp(node, 'stroke'));
+  const strokeWidth = optionalNumberProp(node, 'strokeWidth');
+  const opacity = optionalNumberProp(node, 'opacity');
+  const cornerRadius = optionalNumberProp(node, 'cornerRadius');
 
   if (
     fill === undefined &&
@@ -138,15 +170,15 @@ function paintStyleFromProps(props: JsonObject): PaintStyle | undefined {
   };
 }
 
-function textStyleFromProps(props: JsonObject): TextStyle {
-  const lineHeight = optionalNumberProp(props, 'lineHeight');
-  const align = textAlignFromProp(props);
+function textStyleFromNode(node: GeordiIrNodeV1): TextStyle {
+  const lineHeight = optionalNumberProp(node, 'lineHeight');
+  const align = textAlignFromProp(node);
 
   return {
-    font: stringProp(props, 'fontFamily', 'sans-serif'),
-    size: numberProp(props, 'fontSize', 16),
-    weight: fontWeightFromProp(props),
-    color: stringProp(props, 'color', '#000000'),
+    font: optionalStringProp(node, 'fontFamily') ?? 'sans-serif',
+    size: optionalNumberProp(node, 'fontSize') ?? 16,
+    weight: fontWeightFromProp(node),
+    color: optionalStringProp(node, 'color') ?? '#000000',
     ...(lineHeight !== undefined ? { lineHeight } : {}),
     ...(align !== undefined ? { align } : {}),
   };
@@ -156,8 +188,12 @@ function solidFillFromString(value: string | undefined): SolidFill | undefined {
   return value === undefined ? undefined : { type: 'solid', color: value };
 }
 
-function fontWeightFromProp(props: JsonObject): number {
-  const value = propValue(props, 'fontWeight');
+function fontWeightFromProp(node: GeordiIrNodeV1): number {
+  const value = propValue(node.props, 'fontWeight');
+  if (value === undefined || value === 'normal') {
+    return 400;
+  }
+
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value;
   }
@@ -166,36 +202,74 @@ function fontWeightFromProp(props: JsonObject): number {
     return 700;
   }
 
-  return 400;
+  throw new GeordiRuntimeInvalidNodePropsError(
+    node.id,
+    'fontWeight',
+    'finite number, "normal", or "bold"',
+  );
 }
 
-function textAlignFromProp(props: JsonObject): 'left' | 'center' | 'right' | undefined {
-  const value = propValue(props, 'align');
+function textAlignFromProp(node: GeordiIrNodeV1): 'left' | 'center' | 'right' | undefined {
+  const value = propValue(node.props, 'align');
+  if (value === undefined) {
+    return undefined;
+  }
+
   if (value === 'left' || value === 'center' || value === 'right') {
     return value;
   }
 
-  return undefined;
+  throw new GeordiRuntimeInvalidNodePropsError(
+    node.id,
+    'align',
+    '"left", "center", or "right"',
+  );
 }
 
-function numberProp(props: JsonObject, key: string, fallback: number): number {
-  return optionalNumberProp(props, key) ?? fallback;
+function requiredNumberProp(node: GeordiIrNodeV1, key: string): number {
+  const value = propValue(node.props, key);
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  throw new GeordiRuntimeInvalidNodePropsError(node.id, key, 'finite number');
 }
 
-function optionalNumberProp(props: JsonObject, key: string): number | undefined {
-  const value = propValue(props, key);
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+function optionalNumberProp(node: GeordiIrNodeV1, key: string): number | undefined {
+  const value = propValue(node.props, key);
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  throw new GeordiRuntimeInvalidNodePropsError(node.id, key, 'finite number');
 }
 
-function stringProp(props: JsonObject, key: string, fallback: string): string {
-  return optionalStringProp(props, key) ?? fallback;
+function requiredStringProp(node: GeordiIrNodeV1, key: string): string {
+  const value = propValue(node.props, key);
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  throw new GeordiRuntimeInvalidNodePropsError(node.id, key, 'string');
 }
 
-function optionalStringProp(props: JsonObject, key: string): string | undefined {
-  const value = propValue(props, key);
-  return typeof value === 'string' ? value : undefined;
+function optionalStringProp(node: GeordiIrNodeV1, key: string): string | undefined {
+  const value = propValue(node.props, key);
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  throw new GeordiRuntimeInvalidNodePropsError(node.id, key, 'string');
 }
 
-function propValue(props: JsonObject, key: string) {
+function propValue(props: JsonObject, key: string): JsonValue | undefined {
   return props[key];
 }

--- a/packages/runtime-webgl/src/utils.ts
+++ b/packages/runtime-webgl/src/utils.ts
@@ -2,25 +2,33 @@
  * Utility functions for Geordi rendering
  */
 
-import type { GeordiIrV1, GeordiScene } from '@flyingrobots/geordi-core';
+import type { GeordiIrV1, PreparedGeordiScene } from '@flyingrobots/geordi-core';
 import { GeordiWebGLRenderer } from './WebGLRenderer.js';
 import { prepareGeordiIr } from './prepareGeordiIr.js';
 
 /**
- * Render a Geordi scene to a canvas element
+ * Render a prepared runtime scene to a canvas element.
  *
- * @param scene - The Geordi scene to render
+ * @param scene - The prepared scene to render
  * @returns Canvas element with the rendered scene
  */
-export function renderGeordiToCanvas(scene: GeordiScene): HTMLCanvasElement {
+export function renderPreparedSceneToCanvas(scene: PreparedGeordiScene): HTMLCanvasElement {
   const renderer = new GeordiWebGLRenderer(
     scene.canvas.width,
     scene.canvas.height,
   );
 
-  return renderer.render(scene);
+  return renderer.renderPreparedScene(scene);
 }
 
-export function renderGeordiIrToCanvas(ir: GeordiIrV1): HTMLCanvasElement {
-  return renderGeordiToCanvas(prepareGeordiIr(ir));
+/** Render public `geordi-ir/1` to a canvas element. */
+export function renderGeordiToCanvas(ir: GeordiIrV1): HTMLCanvasElement {
+  return renderPreparedSceneToCanvas(prepareGeordiIr(ir));
 }
+
+/**
+ * Render public `geordi-ir/1` to a canvas element.
+ *
+ * Compatibility alias retained during the v0.1 migration. Use `renderGeordiToCanvas`.
+ */
+export const renderGeordiIrToCanvas = renderGeordiToCanvas;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@flyingrobots/geordi-compiler-core':
+        specifier: workspace:*
+        version: link:../compiler-core
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1


### PR DESCRIPTION
## Summary

Completes the runtime-contract migration started in PR #15:

- Promotes `renderGeordiToCanvas()` to the primary public `geordi-ir/1` rendering API.
- Adds `renderPreparedSceneToCanvas()` for the draw-ready runtime scene shape and keeps `renderGeordiIrToCanvas()` as a compatibility alias.
- Adds `PreparedGeordiScene` and `PreparedGeordiNode` aliases in core so the draw-ready shape is explicitly separated from the public IR contract.
- Validates runtime-bound IR before preparing scenes and throws custom runtime errors for invalid IR, unsupported node kinds, and invalid required node props.
- Makes runtime prop lowering fail loud instead of silently defaulting required drawable props.
- Adds compiler-to-runtime integration coverage: canonical AST JSON is compiled, emitted IR is parsed through the canonical JSON port, validated as `geordi-ir/1`, and rendered through the runtime mock canvas.
- Updates README, backlog, bearing, status, changelog, and design-law docs to mark `geordi-ir/1` as the runtime contract and move the next P0 focus to numeric profile / JSON ownership.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm test:docs`
- `pnpm test:package-names`
- `pnpm test:repo-sludge`
- `pnpm test:placeholders`
- `pnpm test:exports`
- `git diff --check`

## Notes

Compatibility aliases remain during the v0.1 migration, but the documented renderer contract is now `geordi-ir/1`. JSDoc `@deprecated` tags are avoided on aliases where repo tests/imports still touch them because the strict lint config treats deprecated-symbol usage as an error.