### PR TITLE
[codex] Define numeric profile and move JSON port to core

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -45,6 +45,10 @@ Acceptance criteria:
 ### Define the graphics numeric profile
 **Priority**: P0
 **Source**: v0 design laws, graphics determinism discussion
+**Status**: Completed. Core owns the canonical JSON port and the v0
+`geordi-finite-binary64/1` numeric profile. `geordi-ir/1` declares `numericProfile`,
+compiler receipts include it, runtime-webgl declares its supported runtime profile, and runtime
+rendering fails loudly when IR asks for an unsupported profile.
 
 Canonical JSON can make bytes deterministic, but it cannot by itself define graphics fidelity for
 floats, vectors, matrix math, transforms, and shader-adjacent values. The IR needs an explicit
@@ -91,6 +95,9 @@ historical context.
 - `geordi-ir/1` is the runtime contract: core owns IR validation, compiler-core emits the shared
   contract, runtime-webgl validates IR at the boundary, fail-loud prop lowering rejects invalid
   drawable props, and compiler output is rendered through the runtime contract in tests.
+- Graphics numeric profile is explicit: core owns `geordi-finite-binary64/1`, canonical JSON
+  rejects non-finite numbers and canonicalizes `-0`, compiler IR and receipts declare the profile,
+  and runtime-webgl rejects unsupported profile requirements before rendering.
 
 ---
 

--- a/BEARING.md
+++ b/BEARING.md
@@ -1,8 +1,8 @@
 # Geordi Bearing
 
 **Date**: 2026-05-22
-**Branch baseline**: `main` at `16395d0`
-**Current head when written**: `16395d0`
+**Branch baseline**: `main` at `c4597a6`
+**Current head when written**: `c4597a6`
 
 This file is the short-term operating map. Product rationale remains in
 [`docs/V0_DESIGN_LAWS.md`](./docs/V0_DESIGN_LAWS.md); detailed work items remain in
@@ -38,11 +38,15 @@ Completed:
 - The draw-ready runtime scene shape is explicitly named `PreparedGeordiScene`; compatibility
   aliases remain for the v0.1 migration, but `geordi-ir/1` is the documented renderer contract.
 - Compiler-emitted IR is covered end to end through runtime rendering.
+- `@flyingrobots/geordi-core` owns the canonical JSON port, including parse/stringify/normalize
+  behavior and custom JSON error types.
+- `geordi-ir/1` declares `numericProfile: "geordi-finite-binary64/1"`; compiler receipts include
+  that profile, and runtime-webgl rejects unsupported profile requirements before rendering.
 
 Still true:
 
-- The graphics numeric profile is only partially defined. JSON is deterministic, but geometry,
-  vectors, matrices, transforms, and runtime capability declaration are not fully specified.
+- Multi-step geometry, vector, matrix, transform, and animation operation-order rules still need to
+  be specified as those features are introduced.
 
 ## Immediate Moves
 
@@ -50,14 +54,13 @@ Still true:
    - GitHub Actions Dependabot PR #10 was mergeable and has been merged.
    - Conflicting npm Dependabot PR #8 should be recreated by Dependabot before any manual lockfile
      work.
-2. Define and enforce the graphics numeric profile.
-3. Move the canonical JSON port into core so IR validation, deterministic JSON, and numeric law
-   share the same package boundary.
+2. Add source maps and diagnostic UX improvements.
+3. Define the next explicit feature/capability profile beyond the v0 baseline.
 
 ## Recommended P0 Order
 
-1. Define and enforce the graphics numeric profile.
-2. Move canonical JSON ownership into `@flyingrobots/geordi-core`.
+1. Add source maps and diagnostic UX improvements.
+2. Define the next feature/capability profile beyond the v0 baseline.
 
 ## Dependency Work
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Features
 
-- **`@flyingrobots/geordi-core`**: Add core-owned `geordi-ir/1` constants, versioned IR types,
+- **`@flyingrobots/geordi-core`**: Add core-owned `geordi-ir/1` constants, current `GeordiIr` types,
   and structural validation for scenes, nodes, bindings, animations, keyframes, and finite
   numeric fields.
 - **`@flyingrobots/geordi-compiler-core`**: Re-export IR types from
@@ -31,6 +31,9 @@
 - **`@flyingrobots/geordi-runtime-webgl`**: Add `GEORDI_WEBGL_RUNTIME_PROFILE` and fail loudly
   with `GeordiRuntimeUnsupportedProfileError` when IR requests an unsupported IR version or
   numeric profile.
+- **Public API**: De-version the current IR TypeScript surface (`GeordiIr`,
+  `validateGeordiIr()`, `isGeordiIr()`) and compiler target (`geordi-ir`) while preserving
+  `irVersion: "geordi-ir/1"` as the serialized contract identity.
 - **`@flyingrobots/geordi-compiler-core`**: Semantic validation engine — `validateCanonicalAst()` with two-tier rule registry; Tier 1 (structural: `sceneDimensions`, `nodeKindValid`, `duplicateId`, `danglingRef`, `cycleDetection`) gates Tier 2 (semantic: `requiredProps` per NodeKind); iterative Kahn's cycle detection passes 10k-node chains without stack overflow
 - **`@flyingrobots/geordi-compiler-core`**: Deterministic IR emitter — `emitGeordiIrArtifact()` replaces stub; two-phase topological sort (Kahn's on `parentId` DAG, tie-broken `zIndex ASC → kind ASC → id ASC` bytewise); strips `sourceRef` and `__typename`
 - **`@flyingrobots/geordi-compiler-core`**: Determinism certificate — `emitReceiptArtifact()` emits `scene.geordi.json.receipt` alongside IR containing `comparatorVersion`, `inputHash` (SHA-256 of `input.source`), `irHash` (SHA-256 of the emitted IR), `irHashAlg` (`"sha256"`), `irVersion`, and `rulesetFingerprint` (SHA-256 of sorted rule IDs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@
 - **`@flyingrobots/geordi-core`**: Rename the draw-ready scene model at the type level with
   `PreparedGeordiScene` and `PreparedGeordiNode` aliases so the public contract is no longer
   confused with `geordi-ir/1`.
+- **`@flyingrobots/geordi-core`**: Own the v0 graphics numeric profile
+  (`geordi-finite-binary64/1`), graphics-number helpers, and the canonical JSON port with custom
+  parse, non-finite-number, and stringify error types.
+- **`@flyingrobots/geordi-compiler-core`**: Emit `numericProfile` in `scene.geordi.json` and
+  `scene.geordi.json.receipt`, and re-export the core-owned canonical JSON port for compatibility.
+- **`@flyingrobots/geordi-runtime-webgl`**: Add `GEORDI_WEBGL_RUNTIME_PROFILE` and fail loudly
+  with `GeordiRuntimeUnsupportedProfileError` when IR requests an unsupported IR version or
+  numeric profile.
 - **`@flyingrobots/geordi-compiler-core`**: Semantic validation engine — `validateCanonicalAst()` with two-tier rule registry; Tier 1 (structural: `sceneDimensions`, `nodeKindValid`, `duplicateId`, `danglingRef`, `cycleDetection`) gates Tier 2 (semantic: `requiredProps` per NodeKind); iterative Kahn's cycle detection passes 10k-node chains without stack overflow
 - **`@flyingrobots/geordi-compiler-core`**: Deterministic IR emitter — `emitGeordiIrArtifact()` replaces stub; two-phase topological sort (Kahn's on `parentId` DAG, tie-broken `zIndex ASC → kind ASC → id ASC` bytewise); strips `sourceRef` and `__typename`
 - **`@flyingrobots/geordi-compiler-core`**: Determinism certificate — `emitReceiptArtifact()` emits `scene.geordi.json.receipt` alongside IR containing `comparatorVersion`, `inputHash` (SHA-256 of `input.source`), `irHash` (SHA-256 of the emitted IR), `irHashAlg` (`"sha256"`), `irVersion`, and `rulesetFingerprint` (SHA-256 of sorted rule IDs)
@@ -52,6 +60,11 @@
 - **`@flyingrobots/geordi-runtime-webgl`**: add runtime-bound IR validation, fail-loud prop
   lowering, and compiler-to-runtime contract coverage that compiles canonical AST JSON, parses
   emitted IR through the canonical JSON port, validates it as `geordi-ir/1`, and renders it.
+- **`@flyingrobots/geordi-core`**: add canonical JSON port coverage for stable key order,
+  `-0` normalization, nested non-finite-number rejection with paths, deterministic finite float
+  spelling, and no hidden fixed-point scaling.
+- **`@flyingrobots/geordi-runtime-webgl`**: add runtime profile export and unsupported profile
+  rejection coverage.
 - **`@flyingrobots/geordi-wesley-generator`**: add behavior contract tests for `plan()`, successful SDL-to-artifacts generation, and custom failure errors on bad SDL
 - **`@flyingrobots/geordi-runtime-webgl`**: add canvas/context mock behavior tests for rendering the prepared scene contract and context-unavailable failure
 - **`@flyingrobots/geordi-compiler-core`**: 74 new tests across sprint 3 — first batch: `stableStringify` (22), `parseInput` table-driven (9), `determinism` (3) → 36 tests; second batch: `validateAst` (15), `emitTypes` (19), `determinism` +4, `compile.golden` +3 → total 79 tests

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ All Geordi runtimes implement a shared contract:
 
 ```ts
 interface GeordiRuntime {
-  load(ir: GeordiIrV1): Promise<void>;
+  load(ir: GeordiIr): Promise<void>;
   render(): void;
   updateNode(id: string, props: JsonObject): void;
   hitTest(x: number, y: number): HitResult | null;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -127,7 +127,7 @@ All versions are explicit and validated. Unknown versions → hard error.
 
 Current limitations in v0.1:
 - GraphQL directive args use JSON strings for complex props (ugly but pragmatic)
-- Single output target (`geordi-ir-v1`)
+- Single output target (`geordi-ir`)
 - No binary packer (`.geordib` format)
 
 Planned for v0.2:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,6 +118,7 @@ See [`docs/ERROR_CODES.md`](./ERROR_CODES.md) for complete taxonomy.
 
 - **AST version**: `astVersion: "1"` (canonical AST)
 - **IR version**: `irVersion: "geordi-ir/1"` (output format)
+- **Numeric profile**: `numericProfile: "geordi-finite-binary64/1"` (finite binary64 graphics numbers)
 - **Directive version**: `v: "1"` (GraphQL directives)
 
 All versions are explicit and validated. Unknown versions → hard error.

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -139,7 +139,7 @@ All compiler errors use stable, documented error codes. Never ignore or suppress
 
 **Severity**: Error
 **Message**: Unsupported emit target
-**Fix**: Use `target: 'geordi-ir-v1'` (only supported target in v0.1)
+**Fix**: Use `target: 'geordi-ir'` (only supported target in v0.1)
 
 ### `GEORDI_E_FEATURE_NOT_IMPLEMENTED`
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -30,7 +30,7 @@ Pure, framework-agnostic compilation engine.
 
 GraphQL SDL to canonical AST adapter.
 
-- Directive definitions for v1.
+- Directive definitions with an explicit directive version contract.
 - GraphQL parser wrapper with source naming.
 - Scene and node extraction.
 - Canonical AST transform.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -21,8 +21,9 @@ Pure, framework-agnostic compilation engine.
 - Error taxonomy with stable `GEORDI_E_*` and `GEORDI_W_*` codes.
 - Compile orchestrator with parse, canonicalize, validate, and emit phases.
 - GraphQL SDL and canonical JSON input paths.
-- Deterministic JSON port for canonical parse/stringify boundaries.
+- Uses the core-owned deterministic JSON port for canonical parse/stringify boundaries.
 - Deterministic IR, receipt, and TypeScript type emission.
+- IR and receipt emission declare the v0 numeric profile.
 - Post-build public export smoke coverage.
 
 #### `@flyingrobots/geordi-schema-graphql`
@@ -49,6 +50,9 @@ Wesley GeneratorPlugin adapter scaffold.
 Core domain package.
 
 - Versioned `geordi-ir/1` constants, structural types, and validation.
+- Canonical JSON port with deterministic parse/stringify/normalize behavior and custom JSON
+  errors.
+- v0 numeric profile constant `geordi-finite-binary64/1` and graphics-number helpers.
 - Draw-ready runtime scene aliases named `PreparedGeordiScene` and `PreparedGeordiNode`.
 - Compatibility aliases for the older scene names remain during the v0.1 migration.
 
@@ -61,6 +65,8 @@ Canvas-backed WebGL-runtime scaffold.
 - `renderGeordiToCanvas()` is the primary public `geordi-ir/1` rendering API.
 - `renderPreparedSceneToCanvas()` renders draw-ready runtime scenes explicitly.
 - Runtime-bound IR validation and fail-loud prop lowering use custom runtime error types.
+- Runtime capability profile declares supported IR version, numeric profile, node kinds, and visual
+  features.
 - Compiler-emitted IR is rendered through the runtime contract in an integration test.
 
 ## Infrastructure
@@ -85,10 +91,10 @@ Latest full local gate during the core IR runtime-contract work:
 | --- | ---: | --- |
 | `@flyingrobots/geordi-compiler-core` | 73 | Green |
 | `@flyingrobots/geordi-schema-graphql` | 51 | Green |
-| `@flyingrobots/geordi-core` | 12 | Green |
-| `@flyingrobots/geordi-runtime-webgl` | 9 | Green |
+| `@flyingrobots/geordi-core` | 26 | Green |
+| `@flyingrobots/geordi-runtime-webgl` | 12 | Green |
 | `@flyingrobots/geordi-wesley-generator` | 3 | Green |
-| **Total package tests** | **148** | Green |
+| **Total package tests** | **165** | Green |
 
 Additional gates:
 
@@ -107,14 +113,12 @@ Immediate:
 1. Keep dependency hygiene clean.
    - GitHub Actions Dependabot update PR #10 has been merged.
    - npm/yarn Dependabot PR #8 was stale and conflicting; Dependabot has been asked to recreate it.
-2. Move the canonical JSON port into `@flyingrobots/geordi-core`.
-3. Define the graphics numeric profile for geometry, vectors, matrices, transforms, and runtime
-   capability requirements.
+2. Add source maps and diagnostic UX improvements.
+3. Define the next feature/capability profile beyond the v0 baseline.
 
 Short term:
 
-4. Add source maps and diagnostic UX improvements.
-5. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
+4. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
 
 ## Decision Log
 
@@ -132,7 +136,7 @@ Short term:
    - Why: standard, available, and compatible with current tooling.
    - Trade-off: slower than future alternatives such as BLAKE3.
 
-4. **Canonical JSON boundary**: all production JSON ingress/egress goes through the compiler-core
+4. **Canonical JSON boundary**: all production JSON ingress/egress goes through the core-owned
    JSON port.
    - Why: deterministic bytes, strict non-finite number rejection, and one place to define JSON law.
    - Trade-off: boundary code is stricter and less convenient than native `JSON.parse/stringify`.

--- a/docs/V0_DESIGN_LAWS.md
+++ b/docs/V0_DESIGN_LAWS.md
@@ -28,7 +28,7 @@ A renderer may lower IR into an internal draw-ready cache, GPU command list, pac
 ### Consequences
 
 - The draw-ready runtime scene model with `version`, `canvas`, lowercase `type`, `bounds`, and `style` is internal and named `PreparedGeordiScene`.
-- Runtime APIs should consume `GeordiIrV1`; `runtime-webgl` uses `renderGeordiToCanvas(ir)`.
+- Runtime APIs should consume `GeordiIr`; `runtime-webgl` uses `renderGeordiToCanvas(ir)`.
 - Canonical AST remains a compiler-facing interchange shape, not the runtime contract.
 - Renderers must fail loudly when IR requires unsupported features.
 - If a runtime needs preprocessing, expose it as `prepare(ir)` or an internal cache, not as a separate public input format.
@@ -64,7 +64,7 @@ The v0 IR should be small, explicit, and renderable:
 Recommended top-level direction:
 
 ```ts
-interface GeordiIrV1 {
+interface GeordiIr {
   irVersion: 'geordi-ir/1';
   numericProfile: 'geordi-finite-binary64/1';
   requires: string[];
@@ -75,7 +75,7 @@ interface GeordiIrV1 {
 }
 ```
 
-The current repo shape can evolve toward this without breaking the core idea. The important v0 law is that renderers consume `GeordiIrV1`, not a separate legacy scene graph.
+The current repo shape can evolve toward this without breaking the core idea. The important v0 law is that renderers consume `GeordiIr`, not a separate legacy scene graph.
 
 ## Numeric Law
 
@@ -341,7 +341,7 @@ Every IR declares what it requires. Every runtime declares what it supports.
 Recommended baseline profile:
 
 ```text
-geordi/core-v0
+geordi/core/1
 ```
 
 Baseline features:
@@ -360,11 +360,11 @@ Baseline features:
 
 Optional profiles can extend this, for example:
 
-- `layout.flex-v0`
+- `layout.flex/1`
 - `text.raw-runtime-shaping`
-- `effect.shadow-v1`
-- `effect.blur-v1`
-- `animation.keyframes-v1`
+- `effect.shadow/1`
+- `effect.blur/1`
+- `animation.keyframes/1`
 
 ### Failure Mode
 
@@ -504,7 +504,7 @@ These should be answered before locking the v0 IR schema:
 - Should v0 IR use `props.x/y/width/height` temporarily, or should it introduce an explicit `box` field before more runtimes exist?
 - Should `zIndex` remain in emitted IR as debug metadata, or be removed after draw order is resolved?
 - Should layout intent appear in renderable IR, or should renderable IR always contain resolved boxes and optional layout traces?
-- What exact compositor profile should `geordi/core-v0` require for WebGL and future native backends?
+- What exact compositor profile should `geordi/core/1` require for WebGL and future native backends?
 
 ## Recommended Next Step
 

--- a/docs/V0_DESIGN_LAWS.md
+++ b/docs/V0_DESIGN_LAWS.md
@@ -14,7 +14,7 @@ It also defines the v0 design laws that keep Geordi from becoming a generic scen
 
 `geordi-ir/1` is the public renderer contract.
 
-`@flyingrobots/geordi-core` should own the versioned IR types, validation, canonical JSON rules, feature profiles, and capability matching. `@flyingrobots/geordi-compiler-core` should emit `geordi-ir/1`. Renderers such as `@flyingrobots/geordi-runtime-webgl` should accept validated `geordi-ir/1` directly.
+`@flyingrobots/geordi-core` owns the versioned IR types, validation, canonical JSON rules, numeric profile, and compatibility constants. `@flyingrobots/geordi-compiler-core` emits `geordi-ir/1`. Renderers such as `@flyingrobots/geordi-runtime-webgl` accept validated `geordi-ir/1` directly and declare the runtime profile they support.
 
 A renderer may lower IR into an internal draw-ready cache, GPU command list, packed binary, atlas plan, or scene acceleration structure. That lowering is an implementation detail. It must not become a second public scene format unless it has its own version, validator, and explicit reason to exist.
 
@@ -27,8 +27,8 @@ A renderer may lower IR into an internal draw-ready cache, GPU command list, pac
 
 ### Consequences
 
-- The current `core` scene model with `version`, `canvas`, lowercase `type`, `bounds`, and `style` is legacy or internal. It should be migrated, deprecated, or renamed before v0.1 release.
-- Runtime APIs should move toward `render(ir: GeordiIrV1, options?: RenderOptions)`.
+- The draw-ready runtime scene model with `version`, `canvas`, lowercase `type`, `bounds`, and `style` is internal and named `PreparedGeordiScene`.
+- Runtime APIs should consume `GeordiIrV1`; `runtime-webgl` uses `renderGeordiToCanvas(ir)`.
 - Canonical AST remains a compiler-facing interchange shape, not the runtime contract.
 - Renderers must fail loudly when IR requires unsupported features.
 - If a runtime needs preprocessing, expose it as `prepare(ir)` or an internal cache, not as a separate public input format.
@@ -66,6 +66,7 @@ Recommended top-level direction:
 ```ts
 interface GeordiIrV1 {
   irVersion: 'geordi-ir/1';
+  numericProfile: 'geordi-finite-binary64/1';
   requires: string[];
   scene: SceneFrame;
   assets?: AssetManifest;
@@ -80,14 +81,15 @@ The current repo shape can evolve toward this without breaking the core idea. Th
 
 Graphics numbers are part of the rendering contract, not incidental JSON details.
 
-v0 must define a numeric profile before claiming pixel-identical compliance:
+v0 defines `geordi-finite-binary64/1` as the current graphics numeric profile:
 
 - JSON is only a debug, review, and interchange envelope.
 - The JSON port must canonicalize object order, normalize `-0` to `0`, and reject `NaN` and infinities.
 - The JSON port must not silently rescale or round ordinary numbers, because that changes author intent.
-- Geometry, vectors, matrices, transforms, and animation values need an explicit domain scalar.
+- Geometry, vectors, matrices, transforms, and animation values use finite JavaScript/IEEE-754 binary64 numbers in v0, with deterministic operation order still to be specified where multi-step math is introduced.
+- `geordi-ir/1` declares `numericProfile`, compiler receipts include it, and runtimes fail loudly when the requested profile is unsupported.
 
-The preferred direction is an explicit fixed-point IR scalar for layout-critical geometry, for example `px * SCALE` stored as an integer with a named `numericProfile`. A value such as `5.123402px` may lower to `5123402` only if the IR says the field is fixed-point with `scale = 1_000_000`. That conversion belongs in compiler normalization, not hidden inside generic JSON serialization.
+An explicit fixed-point IR scalar can be added later for layout-critical geometry, for example `px * SCALE` stored as an integer under a new named `numericProfile`. A value such as `5.123402px` may lower to `5123402` only if the IR says the field is fixed-point with `scale = 1_000_000`. That conversion belongs in compiler normalization, not hidden inside generic JSON serialization.
 
 Matrix and shader-adjacent math may require a separate profile, such as deterministic binary64 with a fixed operation order or a packed binary representation. This should be specified as a renderer compliance profile before v0 locks the IR schema.
 
@@ -388,7 +390,9 @@ Diagnostics should use stable error codes.
 
 ### Canonical JSON
 
-Canonical JSON is the v0 debug and review format, not the whole graphics fidelity story:
+Canonical JSON is the v0 debug and review format, not the whole graphics fidelity story. The
+canonical JSON port lives in `@flyingrobots/geordi-core`; other packages use or re-export that
+boundary instead of calling `JSON.parse` or `JSON.stringify` directly:
 
 - Stable key order.
 - Stable node order.
@@ -449,8 +453,10 @@ v0.1 migration, but they are no longer the documented public renderer contract.
 
 Canonical JSON alone is not enough for a graphics library. Define the v0 scalar law for geometry, vectors, matrices, transforms, and animation values. Decide which fields lower to fixed-point integers, which may remain deterministic binary64, and how the profile is declared in IR and runtime capabilities.
 
-**Status**: Open. The JSON boundary rejects non-finite numbers and canonicalizes `-0`; graphics
-math and runtime capability semantics remain open.
+**Status**: Completed. `geordi-ir/1` declares `numericProfile: "geordi-finite-binary64/1"`,
+compiler receipts include the profile, runtime-webgl declares and checks its supported profile,
+and the core JSON port rejects non-finite numbers, canonicalizes `-0`, and does not round or
+fixed-point scale ordinary finite values.
 
 ### P0: Validate GraphQL directive argument types at runtime
 
@@ -508,5 +514,5 @@ The first stabilization pass is merged. Continue in this order:
 2. Validate GraphQL directive argument types at runtime.
 3. Lower or explicitly reject every known Geordi directive.
 4. Expand package behavior tests beyond public entrypoint smoke.
-5. Define and enforce the graphics numeric profile.
-6. Move canonical JSON ownership into `@flyingrobots/geordi-core`.
+5. Add source maps and diagnostic UX improvements.
+6. Define the next feature/capability profile beyond the v0 baseline.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -92,7 +92,7 @@ export default [
     },
   },
   {
-    files: ['packages/compiler-core/src/ports/json.ts'],
+    files: ['packages/core/src/ports/json.ts'],
     rules: {
       'no-restricted-syntax': ['error', ...restrictedSyntaxWithoutJsonCalls],
     },

--- a/packages/compiler-core/src/compile/compile.ts
+++ b/packages/compiler-core/src/compile/compile.ts
@@ -22,7 +22,7 @@ import { emitGeordiIrArtifact, emitReceiptArtifact, IR_ARTIFACT_KEY, IR_RECEIPT_
 import { emitTypesArtifact } from './emitTypes.js';
 
 const DEFAULT_OPTIONS: CompileOptions = {
-  target: 'geordi-ir-v1',
+  target: 'geordi-ir',
   emit: {
     irJson: true,
     tsTypes: true,

--- a/packages/compiler-core/src/compile/emitIr.ts
+++ b/packages/compiler-core/src/compile/emitIr.ts
@@ -6,6 +6,7 @@ import {
   GEORDI_IR_HASH_ALGORITHM,
   GEORDI_IR_RECEIPT_KEY,
   GEORDI_IR_VERSION,
+  GEORDI_NUMERIC_PROFILE,
 } from '@flyingrobots/geordi-core';
 import { stringifyCanonicalJson } from '../ports/json.js';
 import { hashString } from '../canonical/hashing.js';
@@ -15,6 +16,7 @@ export const COMPARATOR_VERSION = '1' as const;
 export const IR_VERSION = GEORDI_IR_VERSION;
 export const IR_ARTIFACT_KEY = GEORDI_IR_ARTIFACT_KEY;
 export const IR_RECEIPT_KEY = GEORDI_IR_RECEIPT_KEY;
+export const NUMERIC_PROFILE = GEORDI_NUMERIC_PROFILE;
 
 /**
  * Phase 1: Topological sort by parentId DAG.
@@ -29,6 +31,7 @@ export function emitGeordiIrArtifact(ast: CanonicalSceneAst): Artifact {
   const content = stringifyCanonicalJson(
     {
       irVersion: IR_VERSION,
+      numericProfile: NUMERIC_PROFILE,
       scene: ast.scene,
       nodes: sorted,
       bindings: ast.bindings ?? [],
@@ -63,6 +66,7 @@ export function emitReceiptArtifact(
       irHash,
       irHashAlg: IR_HASH_ALG,
       irVersion: IR_VERSION,
+      numericProfile: NUMERIC_PROFILE,
       rulesetFingerprint,
     },
     { space: 2 },

--- a/packages/compiler-core/src/ports/json.ts
+++ b/packages/compiler-core/src/ports/json.ts
@@ -1,54 +1,34 @@
-import type { JsonObject, JsonValue } from '../types/json.js';
+import {
+  canonicalJsonPort as coreCanonicalJsonPort,
+  GeordiJsonNonFiniteNumberError,
+  GeordiJsonParseError,
+  GeordiJsonStringifyError,
+  normalizeJsonValue as normalizeCoreJsonValue,
+  parseJsonValue as parseCoreJsonValue,
+  stringifyCanonicalJson as stringifyCoreCanonicalJson,
+  type CanonicalJsonOptions,
+} from '@flyingrobots/geordi-core';
+import type { JsonValue } from '../types/json.js';
 
-export interface CanonicalJsonOptions {
-  space?: number | string;
-}
+export type { CanonicalJsonOptions, JsonPort } from '@flyingrobots/geordi-core';
 
-export interface JsonPort {
-  parse(source: string): JsonValue;
-  stringify(value: JsonValue, options?: CanonicalJsonOptions): string;
-  normalize(value: JsonValue): JsonValue;
-}
+export {
+  GeordiJsonNonFiniteNumberError,
+  GeordiJsonParseError,
+  GeordiJsonStringifyError,
+  GeordiJsonNonFiniteNumberError as JsonNonFiniteNumberError,
+  GeordiJsonParseError as JsonParseError,
+  GeordiJsonStringifyError as JsonSerializationError,
+  GeordiJsonStringifyError as JsonStringifyError,
+};
 
-export class JsonParseError extends Error {
-  constructor() {
-    super('Invalid JSON input');
-    this.name = new.target.name;
-  }
-}
-
-export class JsonNonFiniteNumberError extends Error {
-  public readonly path: string;
-
-  constructor(path: string) {
-    super('JSON numbers must be finite');
-    this.name = new.target.name;
-    this.path = path;
-  }
-}
-
-export class JsonSerializationError extends Error {
-  constructor() {
-    super('Canonical JSON serialization failed');
-    this.name = new.target.name;
-  }
-}
-
-export const canonicalJsonPort: JsonPort = {
+export const canonicalJsonPort = {
   parse(source: string): JsonValue {
-    let parsed: JsonValue;
-    try {
-      parsed = JSON.parse(source) as JsonValue;
-    } catch {
-      throw new JsonParseError();
-    }
-
-    return normalizeJsonValue(parsed);
+    return parseJsonValue(source);
   },
 
-  stringify(value: JsonValue, options: CanonicalJsonOptions = {}): string {
-    const normalized = normalizeJsonValue(value);
-    return JSON.stringify(normalized, null, options.space);
+  stringify(value: JsonValue, options?: CanonicalJsonOptions): string {
+    return stringifyCanonicalJson(value, options);
   },
 
   normalize(value: JsonValue): JsonValue {
@@ -57,39 +37,18 @@ export const canonicalJsonPort: JsonPort = {
 };
 
 export function parseJsonValue(source: string): JsonValue {
-  return canonicalJsonPort.parse(source);
+  return parseCoreJsonValue(source) as JsonValue;
 }
 
-export function stringifyCanonicalJson(value: JsonValue, options: CanonicalJsonOptions = {}): string {
-  return canonicalJsonPort.stringify(value, options);
+export function stringifyCanonicalJson(
+  value: JsonValue,
+  options: CanonicalJsonOptions = {},
+): string {
+  return stringifyCoreCanonicalJson(value, options);
 }
 
 export function normalizeJsonValue(value: JsonValue, path = '$'): JsonValue {
-  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
-    return value;
-  }
-
-  if (typeof value === 'number') {
-    if (!Number.isFinite(value)) {
-      throw new JsonNonFiniteNumberError(path);
-    }
-
-    return Object.is(value, -0) ? 0 : value;
-  }
-
-  if (Array.isArray(value)) {
-    return value.map((item, index) => normalizeJsonValue(item, `${path}[${index}]`));
-  }
-
-  const normalized: JsonObject = {};
-  const keys = Object.keys(value).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-
-  for (const key of keys) {
-    const item = value[key];
-    if (item !== undefined) {
-      normalized[key] = normalizeJsonValue(item, `${path}.${key}`);
-    }
-  }
-
-  return normalized;
+  return normalizeCoreJsonValue(value, path) as JsonValue;
 }
+
+export const coreJsonPort = coreCanonicalJsonPort;

--- a/packages/compiler-core/src/types/compiler.ts
+++ b/packages/compiler-core/src/types/compiler.ts
@@ -5,7 +5,7 @@ import type { Diagnostic } from './diagnostics.js';
 export type InputFormat = 'graphql-sdl' | 'canonical-ast-json';
 
 export interface CompileOptions {
-  target: 'geordi-ir-v1';
+  target: 'geordi-ir';
   emit: {
     irJson?: boolean;
     tsTypes?: boolean;

--- a/packages/compiler-core/src/types/ir.ts
+++ b/packages/compiler-core/src/types/ir.ts
@@ -1,9 +1,9 @@
 export type {
-  GeordiIrSceneV1,
-  GeordiIrNodeV1,
-  GeordiIrBindingV1,
-  GeordiIrKeyframeV1,
-  GeordiIrAnimationV1,
-  GeordiIrV1,
+  GeordiIrScene,
+  GeordiIrNode,
+  GeordiIrBinding,
+  GeordiIrKeyframe,
+  GeordiIrAnimation,
+  GeordiIr,
   GeordiNumericProfile,
 } from '@flyingrobots/geordi-core';

--- a/packages/compiler-core/src/types/ir.ts
+++ b/packages/compiler-core/src/types/ir.ts
@@ -5,4 +5,5 @@ export type {
   GeordiIrKeyframeV1,
   GeordiIrAnimationV1,
   GeordiIrV1,
+  GeordiNumericProfile,
 } from '@flyingrobots/geordi-core';

--- a/packages/compiler-core/test/compile.golden.test.ts
+++ b/packages/compiler-core/test/compile.golden.test.ts
@@ -4,7 +4,7 @@ import { GEORDI_NUMERIC_PROFILE } from '@flyingrobots/geordi-core';
 import { compile } from '../src/compile/compile';
 import { GeordiErrorCode } from '../src/errors';
 import { parseJsonValue, stringifyCanonicalJson } from '../src/ports/json';
-import type { GeordiIrV1, JsonObject } from '../src/types';
+import type { GeordiIr, JsonObject } from '../src/types';
 
 function sha256(s: string): string {
   return createHash('sha256').update(s, 'utf8').digest('hex');
@@ -46,7 +46,7 @@ describe('compile() golden path', () => {
       source: stringifyCanonicalJson(validCanonicalAst),
       filename: 'fixtures/valid.scene.json',
       options: {
-        target: 'geordi-ir-v1',
+        target: 'geordi-ir',
         emit: { irJson: true, tsTypes: true, jsonSchema: false, binaryPack: false },
         strict: true,
         failOnWarnings: false,
@@ -59,7 +59,7 @@ describe('compile() golden path', () => {
     expect(result.artifacts['scene.geordi.json']).toBeDefined();
     expect(result.artifacts['types.ts']).toBeDefined();
 
-    const ir = parseJsonValue(String(result.artifacts['scene.geordi.json'].content)) as GeordiIrV1;
+    const ir = parseJsonValue(String(result.artifacts['scene.geordi.json'].content)) as GeordiIr;
     expect(ir.irVersion).toBe('geordi-ir/1');
     expect(ir.numericProfile).toBe(GEORDI_NUMERIC_PROFILE);
     expect(ir.scene.id).toBe('scene:terminal');
@@ -81,7 +81,7 @@ describe('compile() golden path', () => {
     const result = await compile({
       format: 'canonical-ast-json',
       source,
-      options: { target: 'geordi-ir-v1', emit: { irJson: true, tsTypes: false } },
+      options: { target: 'geordi-ir', emit: { irJson: true, tsTypes: false } },
     });
 
     expect(result.ok).toBe(true);
@@ -111,7 +111,7 @@ describe('compile() golden path', () => {
     const result = await compile({
       format: 'canonical-ast-json',
       source,
-      options: { target: 'geordi-ir-v1', emit: { irJson: true, tsTypes: false } },
+      options: { target: 'geordi-ir', emit: { irJson: true, tsTypes: false } },
     });
 
     expect(result.ok).toBe(true);
@@ -130,7 +130,7 @@ describe('compile() golden path', () => {
     const input = {
       format: 'canonical-ast-json' as const,
       source,
-      options: { target: 'geordi-ir-v1' as const, emit: { irJson: true, tsTypes: false } },
+      options: { target: 'geordi-ir' as const, emit: { irJson: true, tsTypes: false } },
     };
 
     const r1 = await compile(input);
@@ -156,7 +156,7 @@ describe('compile() golden path', () => {
     const result = await compile({
       format: 'canonical-ast-json',
       source,
-      options: { target: 'geordi-ir-v1', emit: { jsonSchema: true } },
+      options: { target: 'geordi-ir', emit: { jsonSchema: true } },
     });
 
     expect(result.ok).toBe(false);
@@ -177,7 +177,7 @@ describe('compile() golden path', () => {
       format: 'canonical-ast-json',
       source,
       options: {
-        target: 'geordi-ir-v1',
+        target: 'geordi-ir',
         emit: { irJson: true, tsTypes: true, binaryPack: true },
       },
     });
@@ -194,7 +194,7 @@ describe('compile() golden path', () => {
       source: '   ',
       filename: 'fixtures/invalid.empty.json',
       options: {
-        target: 'geordi-ir-v1',
+        target: 'geordi-ir',
         emit: { irJson: true, tsTypes: true },
         strict: true,
         failOnWarnings: false,

--- a/packages/compiler-core/test/compile.golden.test.ts
+++ b/packages/compiler-core/test/compile.golden.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
+import { GEORDI_NUMERIC_PROFILE } from '@flyingrobots/geordi-core';
 import { compile } from '../src/compile/compile';
 import { GeordiErrorCode } from '../src/errors';
 import { parseJsonValue, stringifyCanonicalJson } from '../src/ports/json';
@@ -60,6 +61,7 @@ describe('compile() golden path', () => {
 
     const ir = parseJsonValue(String(result.artifacts['scene.geordi.json'].content)) as GeordiIrV1;
     expect(ir.irVersion).toBe('geordi-ir/1');
+    expect(ir.numericProfile).toBe(GEORDI_NUMERIC_PROFILE);
     expect(ir.scene.id).toBe('scene:terminal');
     expect(Array.isArray(ir.nodes)).toBe(true);
     expect(ir.nodes.length).toBe(2);
@@ -88,6 +90,7 @@ describe('compile() golden path', () => {
     const receipt = parseJsonValue(String(result.artifacts['scene.geordi.json.receipt'].content)) as JsonObject;
     expect(receipt.comparatorVersion).toBe('1');
     expect(receipt.irVersion).toBe('geordi-ir/1');
+    expect(receipt.numericProfile).toBe(GEORDI_NUMERIC_PROFILE);
     expect(receipt.inputHash).toBe(sha256(source));
     expect(typeof receipt.rulesetFingerprint).toBe('string');
 

--- a/packages/compiler-core/test/coreIrContract.test.ts
+++ b/packages/compiler-core/test/coreIrContract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { validateGeordiIrV1 } from '@flyingrobots/geordi-core';
+import { GEORDI_NUMERIC_PROFILE, validateGeordiIrV1 } from '@flyingrobots/geordi-core';
+import type { GeordiIrV1 } from '@flyingrobots/geordi-core';
 import { compile } from '../src/compile/compile';
 import { parseJsonValue, stringifyCanonicalJson } from '../src/ports/json';
 
@@ -50,5 +51,6 @@ describe('compiler-core to geordi-core IR contract', () => {
 
     const ir = parseJsonValue(String(artifact.content));
     expect(validateGeordiIrV1(ir)).toEqual({ ok: true, issues: [] });
+    expect((ir as GeordiIrV1).numericProfile).toBe(GEORDI_NUMERIC_PROFILE);
   });
 });

--- a/packages/compiler-core/test/coreIrContract.test.ts
+++ b/packages/compiler-core/test/coreIrContract.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { GEORDI_NUMERIC_PROFILE, validateGeordiIrV1 } from '@flyingrobots/geordi-core';
-import type { GeordiIrV1 } from '@flyingrobots/geordi-core';
+import { GEORDI_NUMERIC_PROFILE, validateGeordiIr } from '@flyingrobots/geordi-core';
+import type { GeordiIr } from '@flyingrobots/geordi-core';
 import { compile } from '../src/compile/compile';
 import { parseJsonValue, stringifyCanonicalJson } from '../src/ports/json';
 
@@ -36,7 +36,7 @@ describe('compiler-core to geordi-core IR contract', () => {
       format: 'canonical-ast-json',
       source,
       options: {
-        target: 'geordi-ir-v1',
+        target: 'geordi-ir',
         emit: {
           irJson: true,
           tsTypes: false,
@@ -50,7 +50,7 @@ describe('compiler-core to geordi-core IR contract', () => {
     expect(artifact).toBeDefined();
 
     const ir = parseJsonValue(String(artifact.content));
-    expect(validateGeordiIrV1(ir)).toEqual({ ok: true, issues: [] });
-    expect((ir as GeordiIrV1).numericProfile).toBe(GEORDI_NUMERIC_PROFILE);
+    expect(validateGeordiIr(ir)).toEqual({ ok: true, issues: [] });
+    expect((ir as GeordiIr).numericProfile).toBe(GEORDI_NUMERIC_PROFILE);
   });
 });

--- a/packages/compiler-core/test/determinism.test.ts
+++ b/packages/compiler-core/test/determinism.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import { compile } from '../src/compile/compile';
 import { parseJsonValue, stringifyCanonicalJson } from '../src/ports/json';
-import type { CompilerInput, GeordiIrV1 } from '../src/types';
+import type { CompilerInput, GeordiIr } from '../src/types';
 
 function sha256(content: string): string {
   return createHash('sha256').update(content, 'utf8').digest('hex');
@@ -39,7 +39,7 @@ const BASE_INPUT: CompilerInput = {
   }),
   filename: 'fixtures/determinism.json',
   options: {
-    target: 'geordi-ir-v1',
+    target: 'geordi-ir',
     emit: { irJson: true, tsTypes: false },
     strict: true,
     failOnWarnings: false,
@@ -172,7 +172,7 @@ describe('determinism', () => {
     const result = await compile(withReversedNodes);
     expect(result.ok).toBe(true);
 
-    const ir = parseJsonValue(String(result.artifacts['scene.geordi.json'].content)) as GeordiIrV1;
+    const ir = parseJsonValue(String(result.artifacts['scene.geordi.json'].content)) as GeordiIr;
     expect(ir.nodes.map((n) => n.id)).toEqual(['node:z1', 'node:z2', 'node:z3']);
   });
 
@@ -235,7 +235,7 @@ describe('determinism', () => {
     const result = await compile(input);
     expect(result.ok).toBe(true);
 
-    const ir = parseJsonValue(String(result.artifacts['scene.geordi.json'].content)) as GeordiIrV1;
+    const ir = parseJsonValue(String(result.artifacts['scene.geordi.json'].content)) as GeordiIr;
     const ids = ir.nodes.map((n) => n.id);
     expect(ids.indexOf('parent')).toBeLessThan(ids.indexOf('child'));
   });
@@ -259,7 +259,7 @@ describe('determinism', () => {
     const result = await compile(input);
     expect(result.ok).toBe(true);
 
-    const ir = parseJsonValue(String(result.artifacts['scene.geordi.json'].content)) as GeordiIrV1;
+    const ir = parseJsonValue(String(result.artifacts['scene.geordi.json'].content)) as GeordiIr;
     expect(ir.nodes.map((n) => n.id)).toEqual(['n:a', 'n:z']);
   });
 });

--- a/packages/core/src/domain/models/GeordiIr.test.ts
+++ b/packages/core/src/domain/models/GeordiIr.test.ts
@@ -4,9 +4,11 @@ import {
   isGeordiIrV1,
   validateGeordiIrV1,
 } from './GeordiIr';
+import { GEORDI_NUMERIC_PROFILE } from './GeordiNumericProfile';
 
 const VALID_IR = {
   irVersion: GEORDI_IR_VERSION,
+  numericProfile: GEORDI_NUMERIC_PROFILE,
   scene: {
     id: 'scene:test',
     width: 320,
@@ -47,6 +49,22 @@ describe('Geordi IR v1 contract', () => {
 
     expect(result.ok).toBe(false);
     expect(result.issues.map((issue) => issue.path)).toContain('$.irVersion');
+  });
+
+  it('rejects missing or unsupported numeric profiles', () => {
+    const missingProfile = { ...VALID_IR };
+    Reflect.deleteProperty(missingProfile, 'numericProfile');
+
+    const missingResult = validateGeordiIrV1(missingProfile);
+    const unsupportedResult = validateGeordiIrV1({
+      ...VALID_IR,
+      numericProfile: 'geordi-fixed-point-px6/1',
+    });
+
+    expect(missingResult.ok).toBe(false);
+    expect(unsupportedResult.ok).toBe(false);
+    expect(missingResult.issues.map((issue) => issue.path)).toContain('$.numericProfile');
+    expect(unsupportedResult.issues.map((issue) => issue.path)).toContain('$.numericProfile');
   });
 
   it('rejects non-finite scene dimensions and node z-index', () => {

--- a/packages/core/src/domain/models/GeordiIr.test.ts
+++ b/packages/core/src/domain/models/GeordiIr.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   GEORDI_IR_VERSION,
-  isGeordiIrV1,
-  validateGeordiIrV1,
+  isGeordiIr,
+  validateGeordiIr,
 } from './GeordiIr';
 import { GEORDI_NUMERIC_PROFILE } from './GeordiNumericProfile';
 
@@ -33,16 +33,16 @@ const VALID_IR = {
   animations: [],
 };
 
-describe('Geordi IR v1 contract', () => {
+describe('Geordi IR contract', () => {
   it('accepts a valid geordi-ir/1 document', () => {
-    const result = validateGeordiIrV1(VALID_IR);
+    const result = validateGeordiIr(VALID_IR);
 
     expect(result).toEqual({ ok: true, issues: [] });
-    expect(isGeordiIrV1(VALID_IR)).toBe(true);
+    expect(isGeordiIr(VALID_IR)).toBe(true);
   });
 
   it('rejects the wrong IR version', () => {
-    const result = validateGeordiIrV1({
+    const result = validateGeordiIr({
       ...VALID_IR,
       irVersion: 'geordi-ir/2',
     });
@@ -55,8 +55,8 @@ describe('Geordi IR v1 contract', () => {
     const missingProfile = { ...VALID_IR };
     Reflect.deleteProperty(missingProfile, 'numericProfile');
 
-    const missingResult = validateGeordiIrV1(missingProfile);
-    const unsupportedResult = validateGeordiIrV1({
+    const missingResult = validateGeordiIr(missingProfile);
+    const unsupportedResult = validateGeordiIr({
       ...VALID_IR,
       numericProfile: 'geordi-fixed-point-px6/1',
     });
@@ -68,7 +68,7 @@ describe('Geordi IR v1 contract', () => {
   });
 
   it('rejects non-finite scene dimensions and node z-index', () => {
-    const result = validateGeordiIrV1({
+    const result = validateGeordiIr({
       ...VALID_IR,
       scene: {
         id: 'scene:test',
@@ -94,7 +94,7 @@ describe('Geordi IR v1 contract', () => {
   });
 
   it('rejects non-positive scene dimensions', () => {
-    const result = validateGeordiIrV1({
+    const result = validateGeordiIr({
       ...VALID_IR,
       scene: {
         id: 'scene:test',
@@ -111,7 +111,7 @@ describe('Geordi IR v1 contract', () => {
   });
 
   it('rejects nodes without object props', () => {
-    const result = validateGeordiIrV1({
+    const result = validateGeordiIr({
       ...VALID_IR,
       nodes: [
         {

--- a/packages/core/src/domain/models/GeordiIr.ts
+++ b/packages/core/src/domain/models/GeordiIr.ts
@@ -10,7 +10,7 @@ export const GEORDI_IR_ARTIFACT_KEY = 'scene.geordi.json' as const;
 export const GEORDI_IR_RECEIPT_KEY = 'scene.geordi.json.receipt' as const;
 export const GEORDI_IR_HASH_ALGORITHM = 'sha256' as const;
 
-export interface GeordiIrSceneV1 extends JsonObject {
+export interface GeordiIrScene extends JsonObject {
   readonly id: string;
   readonly width: number;
   readonly height: number;
@@ -18,7 +18,7 @@ export interface GeordiIrSceneV1 extends JsonObject {
   readonly background?: string;
 }
 
-export interface GeordiIrNodeV1 extends JsonObject {
+export interface GeordiIrNode extends JsonObject {
   readonly id: string;
   readonly kind: string;
   readonly parentId?: string;
@@ -29,7 +29,7 @@ export interface GeordiIrNodeV1 extends JsonObject {
   readonly style?: JsonObject;
 }
 
-export interface GeordiIrBindingV1 extends JsonObject {
+export interface GeordiIrBinding extends JsonObject {
   readonly id: string;
   readonly targetNodeId: string;
   readonly targetProp: string;
@@ -37,27 +37,27 @@ export interface GeordiIrBindingV1 extends JsonObject {
   readonly when?: string;
 }
 
-export interface GeordiIrKeyframeV1 extends JsonObject {
+export interface GeordiIrKeyframe extends JsonObject {
   readonly t: number;
   readonly value: JsonValue;
 }
 
-export interface GeordiIrAnimationV1 extends JsonObject {
+export interface GeordiIrAnimation extends JsonObject {
   readonly id: string;
   readonly targetNodeId: string;
   readonly property: string;
-  readonly keyframes: readonly GeordiIrKeyframeV1[];
+  readonly keyframes: readonly GeordiIrKeyframe[];
   readonly easing?: string;
   readonly loop?: boolean;
 }
 
-export interface GeordiIrV1 extends JsonObject {
+export interface GeordiIr extends JsonObject {
   readonly irVersion: typeof GEORDI_IR_VERSION;
   readonly numericProfile: GeordiNumericProfile;
-  readonly scene: GeordiIrSceneV1;
-  readonly nodes: readonly GeordiIrNodeV1[];
-  readonly bindings?: readonly GeordiIrBindingV1[];
-  readonly animations?: readonly GeordiIrAnimationV1[];
+  readonly scene: GeordiIrScene;
+  readonly nodes: readonly GeordiIrNode[];
+  readonly bindings?: readonly GeordiIrBinding[];
+  readonly animations?: readonly GeordiIrAnimation[];
 }
 
 export interface GeordiIrValidationIssue extends JsonObject {
@@ -70,11 +70,11 @@ export interface GeordiIrValidationResult {
   readonly issues: readonly GeordiIrValidationIssue[];
 }
 
-export function isGeordiIrV1(value: JsonValue | undefined): value is GeordiIrV1 {
-  return validateGeordiIrV1(value).ok;
+export function isGeordiIr(value: JsonValue | undefined): value is GeordiIr {
+  return validateGeordiIr(value).ok;
 }
 
-export function validateGeordiIrV1(value: JsonValue | undefined): GeordiIrValidationResult {
+export function validateGeordiIr(value: JsonValue | undefined): GeordiIrValidationResult {
   const issues: GeordiIrValidationIssue[] = [];
 
   if (!isJsonObject(value)) {

--- a/packages/core/src/domain/models/GeordiIr.ts
+++ b/packages/core/src/domain/models/GeordiIr.ts
@@ -1,4 +1,9 @@
 import type { JsonObject, JsonValue } from './GeordiScene.js';
+import {
+  GEORDI_NUMERIC_PROFILE,
+  isFiniteGraphicsNumber,
+  type GeordiNumericProfile,
+} from './GeordiNumericProfile.js';
 
 export const GEORDI_IR_VERSION = 'geordi-ir/1' as const;
 export const GEORDI_IR_ARTIFACT_KEY = 'scene.geordi.json' as const;
@@ -48,6 +53,7 @@ export interface GeordiIrAnimationV1 extends JsonObject {
 
 export interface GeordiIrV1 extends JsonObject {
   readonly irVersion: typeof GEORDI_IR_VERSION;
+  readonly numericProfile: GeordiNumericProfile;
   readonly scene: GeordiIrSceneV1;
   readonly nodes: readonly GeordiIrNodeV1[];
   readonly bindings?: readonly GeordiIrBindingV1[];
@@ -78,6 +84,14 @@ export function validateGeordiIrV1(value: JsonValue | undefined): GeordiIrValida
 
   if (property(value, 'irVersion') !== GEORDI_IR_VERSION) {
     pushIssue(issues, '$.irVersion', `IR version must be "${GEORDI_IR_VERSION}"`);
+  }
+
+  if (property(value, 'numericProfile') !== GEORDI_NUMERIC_PROFILE) {
+    pushIssue(
+      issues,
+      '$.numericProfile',
+      `IR numeric profile must be "${GEORDI_NUMERIC_PROFILE}"`,
+    );
   }
 
   validateScene(property(value, 'scene'), issues);
@@ -299,7 +313,7 @@ function isJsonArray(value: JsonValue | undefined): value is readonly JsonValue[
 }
 
 function isFiniteNumber(value: JsonValue | undefined): value is number {
-  return typeof value === 'number' && Number.isFinite(value);
+  return isFiniteGraphicsNumber(value);
 }
 
 function property(object: JsonObject, key: string): JsonValue | undefined {

--- a/packages/core/src/domain/models/GeordiNumericProfile.test.ts
+++ b/packages/core/src/domain/models/GeordiNumericProfile.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GEORDI_NUMERIC_PROFILE,
+  GeordiInvalidGraphicsNumberError,
+  isFiniteGraphicsNumber,
+  requireFiniteGraphicsNumber,
+} from './GeordiNumericProfile';
+
+describe('Geordi numeric profile', () => {
+  it('pins the v0 graphics numeric profile', () => {
+    expect(GEORDI_NUMERIC_PROFILE).toBe('geordi-finite-binary64/1');
+  });
+
+  it('accepts only finite graphics numbers', () => {
+    expect(isFiniteGraphicsNumber(5.123402)).toBe(true);
+    expect(isFiniteGraphicsNumber(-0)).toBe(true);
+    expect(isFiniteGraphicsNumber(Number.NaN)).toBe(false);
+    expect(isFiniteGraphicsNumber(Number.POSITIVE_INFINITY)).toBe(false);
+    expect(isFiniteGraphicsNumber('5')).toBe(false);
+  });
+
+  it('throws a custom error for invalid graphics numbers', () => {
+    expect(() => requireFiniteGraphicsNumber(Number.NEGATIVE_INFINITY, '$.x')).toThrow(
+      GeordiInvalidGraphicsNumberError,
+    );
+  });
+});

--- a/packages/core/src/domain/models/GeordiNumericProfile.ts
+++ b/packages/core/src/domain/models/GeordiNumericProfile.ts
@@ -1,0 +1,30 @@
+import type { JsonValue } from './GeordiScene.js';
+
+export const GEORDI_NUMERIC_PROFILE = 'geordi-finite-binary64/1' as const;
+
+export type GeordiNumericProfile = typeof GEORDI_NUMERIC_PROFILE;
+
+export class GeordiInvalidGraphicsNumberError extends Error {
+  public readonly path: string;
+
+  constructor(path: string) {
+    super('Invalid graphics number');
+    this.name = new.target.name;
+    this.path = path;
+  }
+}
+
+export function isFiniteGraphicsNumber(value: JsonValue | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+export function requireFiniteGraphicsNumber(
+  value: JsonValue | undefined,
+  path: string,
+): number {
+  if (isFiniteGraphicsNumber(value)) {
+    return value;
+  }
+
+  throw new GeordiInvalidGraphicsNumberError(path);
+}

--- a/packages/core/src/domain/models/index.ts
+++ b/packages/core/src/domain/models/index.ts
@@ -71,3 +71,12 @@ export type {
   GeordiIrValidationIssue,
   GeordiIrValidationResult,
 } from './GeordiIr.js';
+
+export {
+  GEORDI_NUMERIC_PROFILE,
+  GeordiInvalidGraphicsNumberError,
+  isFiniteGraphicsNumber,
+  requireFiniteGraphicsNumber,
+} from './GeordiNumericProfile.js';
+
+export type { GeordiNumericProfile } from './GeordiNumericProfile.js';

--- a/packages/core/src/domain/models/index.ts
+++ b/packages/core/src/domain/models/index.ts
@@ -57,17 +57,17 @@ export {
   GEORDI_IR_ARTIFACT_KEY,
   GEORDI_IR_RECEIPT_KEY,
   GEORDI_IR_HASH_ALGORITHM,
-  isGeordiIrV1,
-  validateGeordiIrV1,
+  isGeordiIr,
+  validateGeordiIr,
 } from './GeordiIr.js';
 
 export type {
-  GeordiIrSceneV1,
-  GeordiIrNodeV1,
-  GeordiIrBindingV1,
-  GeordiIrKeyframeV1,
-  GeordiIrAnimationV1,
-  GeordiIrV1,
+  GeordiIrScene,
+  GeordiIrNode,
+  GeordiIrBinding,
+  GeordiIrKeyframe,
+  GeordiIrAnimation,
+  GeordiIr,
   GeordiIrValidationIssue,
   GeordiIrValidationResult,
 } from './GeordiIr.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,3 +6,4 @@
  */
 
 export * from './domain/models/index.js';
+export * from './ports/json.js';

--- a/packages/core/src/ports/json.test.ts
+++ b/packages/core/src/ports/json.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GeordiJsonNonFiniteNumberError,
+  GeordiJsonParseError,
+  parseJsonValue,
+  stringifyCanonicalJson,
+} from './json';
+import type { JsonObject } from '../domain/models/GeordiScene';
+
+describe('canonical JSON port', () => {
+  it('sorts object keys lexicographically', () => {
+    const obj = { z: 1, a: 2, m: 3 };
+    expect(stringifyCanonicalJson(obj)).toBe('{"a":2,"m":3,"z":1}');
+  });
+
+  it('sorts keys in deeply nested objects', () => {
+    const parsed = parseJsonValue('{"z":{"y":1,"b":2},"a":{"x":3,"c":4}}') as JsonObject;
+    expect(Object.keys(parsed)).toEqual(['a', 'z']);
+
+    const a = parsed.a as JsonObject;
+    const z = parsed.z as JsonObject;
+    expect(Object.keys(a)).toEqual(['c', 'x']);
+    expect(Object.keys(z)).toEqual(['b', 'y']);
+  });
+
+  it('produces identical output for same object regardless of insertion order', () => {
+    const a = { c: 3, a: 1, b: 2 };
+    const b = { a: 1, b: 2, c: 3 };
+    expect(stringifyCanonicalJson(a)).toBe(stringifyCanonicalJson(b));
+  });
+
+  it('normalizes negative zero to zero', () => {
+    expect(stringifyCanonicalJson({ value: -0 })).toBe('{"value":0}');
+  });
+
+  it('rejects non-finite numbers instead of silently changing them', () => {
+    expect(() => stringifyCanonicalJson({ value: Number.NaN })).toThrow(
+      GeordiJsonNonFiniteNumberError,
+    );
+    expect(() => stringifyCanonicalJson({ value: Number.POSITIVE_INFINITY })).toThrow(
+      GeordiJsonNonFiniteNumberError,
+    );
+    expect(() => stringifyCanonicalJson({ value: Number.NEGATIVE_INFINITY })).toThrow(
+      GeordiJsonNonFiniteNumberError,
+    );
+  });
+
+  it('rejects nested non-finite numbers with their JSON path', () => {
+    expect(() => stringifyCanonicalJson({ nested: [{ value: Number.NaN }] })).toThrow(
+      GeordiJsonNonFiniteNumberError,
+    );
+
+    let path = '';
+    try {
+      stringifyCanonicalJson({ nested: [{ value: Number.NaN }] });
+    } catch (cause) {
+      if (cause instanceof GeordiJsonNonFiniteNumberError) {
+        path = cause.path;
+      }
+    }
+    expect(path).toBe('$.nested[0].value');
+  });
+
+  it('uses deterministic ECMAScript number spelling for finite floats', () => {
+    expect(stringifyCanonicalJson({ value: 5.123402 })).toBe('{"value":5.123402}');
+    expect(stringifyCanonicalJson({ value: 0.000001 })).toBe('{"value":0.000001}');
+  });
+
+  it('does not round or fixed-point scale ordinary finite numbers', () => {
+    expect(stringifyCanonicalJson({ value: 5123402 })).toBe('{"value":5123402}');
+    expect(stringifyCanonicalJson({ value: 5.123402 })).not.toBe('{"value":5123402}');
+  });
+
+  it('preserves array order while canonicalizing nested object keys', () => {
+    expect(stringifyCanonicalJson([{ z: 1, a: 2 }, { b: 3 }])).toBe(
+      '[{"a":2,"z":1},{"b":3}]',
+    );
+  });
+
+  it('throws a custom parse error for invalid JSON input', () => {
+    expect(() => parseJsonValue('{not json')).toThrow(GeordiJsonParseError);
+  });
+});

--- a/packages/core/src/ports/json.ts
+++ b/packages/core/src/ports/json.ts
@@ -1,0 +1,111 @@
+import type { JsonObject, JsonValue } from '../domain/models/GeordiScene.js';
+
+export interface CanonicalJsonOptions {
+  readonly space?: number | string;
+}
+
+export interface JsonPort {
+  parse(source: string): JsonValue;
+  stringify(value: JsonValue, options?: CanonicalJsonOptions): string;
+  normalize(value: JsonValue): JsonValue;
+}
+
+export class GeordiJsonParseError extends Error {
+  constructor() {
+    super('Invalid JSON input');
+    this.name = new.target.name;
+  }
+}
+
+export class GeordiJsonNonFiniteNumberError extends Error {
+  public readonly path: string;
+
+  constructor(path: string) {
+    super('JSON numbers must be finite');
+    this.name = new.target.name;
+    this.path = path;
+  }
+}
+
+export class GeordiJsonStringifyError extends Error {
+  constructor() {
+    super('Canonical JSON serialization failed');
+    this.name = new.target.name;
+  }
+}
+
+export const canonicalJsonPort: JsonPort = {
+  parse(source: string): JsonValue {
+    let parsed: JsonValue;
+    try {
+      parsed = JSON.parse(source) as JsonValue;
+    } catch {
+      throw new GeordiJsonParseError();
+    }
+
+    return normalizeJsonValue(parsed);
+  },
+
+  stringify(value: JsonValue, options: CanonicalJsonOptions = {}): string {
+    const normalized = normalizeJsonValue(value);
+    try {
+      return JSON.stringify(normalized, null, options.space);
+    } catch {
+      throw new GeordiJsonStringifyError();
+    }
+  },
+
+  normalize(value: JsonValue): JsonValue {
+    return normalizeJsonValue(value);
+  },
+};
+
+export function parseJsonValue(source: string): JsonValue {
+  return canonicalJsonPort.parse(source);
+}
+
+export function stringifyCanonicalJson(
+  value: JsonValue,
+  options: CanonicalJsonOptions = {},
+): string {
+  return canonicalJsonPort.stringify(value, options);
+}
+
+export function normalizeJsonValue(value: JsonValue, path = '$'): JsonValue {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new GeordiJsonNonFiniteNumberError(path);
+    }
+
+    return Object.is(value, -0) ? 0 : value;
+  }
+
+  if (isJsonArray(value)) {
+    return value.map((item, index) => normalizeJsonValue(item, `${path}[${index}]`));
+  }
+
+  const object = value;
+  const normalized: Record<string, JsonValue | undefined> = {};
+  const keys = Object.keys(object).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+
+  for (const key of keys) {
+    const item = property(object, key);
+    if (item !== undefined) {
+      normalized[key] = normalizeJsonValue(item, `${path}.${key}`);
+    }
+  }
+
+  return normalized;
+}
+
+function isJsonArray(value: JsonValue): value is readonly JsonValue[] {
+  return Array.isArray(value);
+}
+
+function property(object: JsonObject, key: string): JsonValue | undefined {
+  return object[key];
+}

--- a/packages/runtime-webgl/src/index.test.ts
+++ b/packages/runtime-webgl/src/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  GEORDI_NUMERIC_PROFILE,
   isGeordiIrV1,
   type GeordiIrV1,
   type PreparedGeordiScene,
@@ -13,7 +14,9 @@ import {
   GeordiCanvasContextUnavailableError,
   GeordiRuntimeInvalidIrError,
   GeordiRuntimeInvalidNodePropsError,
+  GeordiRuntimeUnsupportedProfileError,
   GeordiWebGLRenderer,
+  GEORDI_WEBGL_RUNTIME_PROFILE,
   renderGeordiIrToCanvas,
   renderPreparedSceneToCanvas,
   renderGeordiToCanvas,
@@ -183,6 +186,7 @@ function makePreparedScene(): PreparedGeordiScene {
 function makeIr(): GeordiIrV1 {
   return {
     irVersion: 'geordi-ir/1',
+    numericProfile: GEORDI_NUMERIC_PROFILE,
     scene: {
       id: 'scene:runtime-ir',
       width: 100,
@@ -227,6 +231,15 @@ describe('runtime-webgl public API', () => {
     expect(GeordiWebGLRenderer).toBeTypeOf('function');
     expect(renderGeordiToCanvas).toBeTypeOf('function');
     expect(renderPreparedSceneToCanvas).toBeTypeOf('function');
+  });
+
+  it('exports a runtime capability profile', () => {
+    expect(GEORDI_WEBGL_RUNTIME_PROFILE).toEqual({
+      irVersion: 'geordi-ir/1',
+      numericProfile: GEORDI_NUMERIC_PROFILE,
+      nodeKinds: ['Rect', 'Text', 'Group', 'Image'],
+      visualFeatures: ['solid-fill', 'solid-stroke', 'opacity', 'corner-radius', 'text-fill'],
+    });
   });
 
   it('renders prepared scenes to a canvas context', () => {
@@ -294,6 +307,28 @@ describe('runtime-webgl public API', () => {
     } as object as GeordiIrV1;
 
     expect(() => renderGeordiToCanvas(invalidIr)).toThrow(GeordiRuntimeInvalidIrError);
+  });
+
+  it('throws a custom error for unsupported runtime profile requirements', () => {
+    const unsupportedProfileIr = {
+      ...makeIr(),
+      numericProfile: 'geordi-fixed-point-px6/1',
+    } as object as GeordiIrV1;
+
+    expect(() => renderGeordiToCanvas(unsupportedProfileIr)).toThrow(
+      GeordiRuntimeUnsupportedProfileError,
+    );
+  });
+
+  it('throws a custom error for unsupported IR versions', () => {
+    const unsupportedVersionIr = {
+      ...makeIr(),
+      irVersion: 'geordi-ir/2',
+    } as object as GeordiIrV1;
+
+    expect(() => renderGeordiToCanvas(unsupportedVersionIr)).toThrow(
+      GeordiRuntimeUnsupportedProfileError,
+    );
   });
 
   it('throws a custom error when required runtime node props are missing', () => {

--- a/packages/runtime-webgl/src/index.test.ts
+++ b/packages/runtime-webgl/src/index.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   GEORDI_NUMERIC_PROFILE,
-  isGeordiIrV1,
-  type GeordiIrV1,
+  isGeordiIr,
+  type GeordiIr,
   type PreparedGeordiScene,
 } from '@flyingrobots/geordi-core';
 import {
@@ -183,7 +183,7 @@ function makePreparedScene(): PreparedGeordiScene {
   };
 }
 
-function makeIr(): GeordiIrV1 {
+function makeIr(): GeordiIr {
   return {
     irVersion: 'geordi-ir/1',
     numericProfile: GEORDI_NUMERIC_PROFILE,
@@ -304,7 +304,7 @@ describe('runtime-webgl public API', () => {
         width: 0,
         height: 50,
       },
-    } as object as GeordiIrV1;
+    } as object as GeordiIr;
 
     expect(() => renderGeordiToCanvas(invalidIr)).toThrow(GeordiRuntimeInvalidIrError);
   });
@@ -313,7 +313,7 @@ describe('runtime-webgl public API', () => {
     const unsupportedProfileIr = {
       ...makeIr(),
       numericProfile: 'geordi-fixed-point-px6/1',
-    } as object as GeordiIrV1;
+    } as object as GeordiIr;
 
     expect(() => renderGeordiToCanvas(unsupportedProfileIr)).toThrow(
       GeordiRuntimeUnsupportedProfileError,
@@ -324,7 +324,7 @@ describe('runtime-webgl public API', () => {
     const unsupportedVersionIr = {
       ...makeIr(),
       irVersion: 'geordi-ir/2',
-    } as object as GeordiIrV1;
+    } as object as GeordiIr;
 
     expect(() => renderGeordiToCanvas(unsupportedVersionIr)).toThrow(
       GeordiRuntimeUnsupportedProfileError,
@@ -332,7 +332,7 @@ describe('runtime-webgl public API', () => {
   });
 
   it('throws a custom error when required runtime node props are missing', () => {
-    const invalidIr: GeordiIrV1 = {
+    const invalidIr: GeordiIr = {
       ...makeIr(),
       nodes: [
         {
@@ -351,7 +351,7 @@ describe('runtime-webgl public API', () => {
   });
 
   it('throws a custom error when required string props are invalid', () => {
-    const invalidIr: GeordiIrV1 = {
+    const invalidIr: GeordiIr = {
       ...makeIr(),
       nodes: [
         {
@@ -421,7 +421,7 @@ describe('runtime-webgl public API', () => {
       format: 'canonical-ast-json',
       source,
       options: {
-        target: 'geordi-ir-v1',
+        target: 'geordi-ir',
         emit: {
           irJson: true,
           tsTypes: false,
@@ -436,7 +436,7 @@ describe('runtime-webgl public API', () => {
 
     const artifact = result.artifacts['scene.geordi.json'];
     const ir = parseJsonValue(String(artifact.content));
-    if (!isGeordiIrV1(ir)) {
+    if (!isGeordiIr(ir)) {
       throw new RuntimeContractTestError('Invalid IR artifact');
     }
 

--- a/packages/runtime-webgl/src/index.ts
+++ b/packages/runtime-webgl/src/index.ts
@@ -11,6 +11,16 @@ export {
   GeordiRuntimeUnsupportedNodeKindError,
 } from './prepareGeordiIr.js';
 export {
+  assertSupportedRuntimeProfile,
+  GEORDI_WEBGL_RUNTIME_PROFILE,
+  GeordiRuntimeUnsupportedProfileError,
+} from './profile.js';
+export type {
+  GeordiRuntimeNodeKind,
+  GeordiRuntimeProfile,
+  GeordiRuntimeVisualFeature,
+} from './profile.js';
+export {
   renderGeordiIrToCanvas,
   renderGeordiToCanvas,
   renderPreparedSceneToCanvas,

--- a/packages/runtime-webgl/src/prepareGeordiIr.ts
+++ b/packages/runtime-webgl/src/prepareGeordiIr.ts
@@ -1,8 +1,8 @@
-import { validateGeordiIrV1 } from '@flyingrobots/geordi-core';
+import { validateGeordiIr } from '@flyingrobots/geordi-core';
 import type {
   Bounds,
-  GeordiIrNodeV1,
-  GeordiIrV1,
+  GeordiIrNode,
+  GeordiIr,
   GeordiIrValidationIssue,
   JsonObject,
   JsonValue,
@@ -49,10 +49,10 @@ export class GeordiRuntimeInvalidNodePropsError extends Error {
   }
 }
 
-export function prepareGeordiIr(ir: GeordiIrV1): PreparedGeordiScene {
+export function prepareGeordiIr(ir: GeordiIr): PreparedGeordiScene {
   assertSupportedRuntimeProfile(ir);
 
-  const result = validateGeordiIrV1(ir);
+  const result = validateGeordiIr(ir);
   if (!result.ok) {
     throw new GeordiRuntimeInvalidIrError(result.issues);
   }
@@ -75,7 +75,7 @@ export function prepareGeordiIr(ir: GeordiIrV1): PreparedGeordiScene {
   };
 }
 
-function prepareNode(node: GeordiIrNodeV1, children: readonly string[]): PreparedGeordiNode {
+function prepareNode(node: GeordiIrNode, children: readonly string[]): PreparedGeordiNode {
   switch (node.kind) {
     case 'Rect':
       return {
@@ -121,13 +121,13 @@ function prepareNode(node: GeordiIrNodeV1, children: readonly string[]): Prepare
   }
 }
 
-function childIdsFor(ir: GeordiIrV1, parentId: string): string[] {
+function childIdsFor(ir: GeordiIr, parentId: string): string[] {
   return ir.nodes
     .filter((node) => node.parentId === parentId)
     .map((node) => node.id);
 }
 
-function boundsFromNode(node: GeordiIrNodeV1, requireSize: boolean): Bounds {
+function boundsFromNode(node: GeordiIrNode, requireSize: boolean): Bounds {
   return [
     optionalNumberProp(node, 'x') ?? 0,
     optionalNumberProp(node, 'y') ?? 0,
@@ -136,18 +136,18 @@ function boundsFromNode(node: GeordiIrNodeV1, requireSize: boolean): Bounds {
   ];
 }
 
-function styleFromNode(node: GeordiIrNodeV1): NodeStyle {
+function styleFromNode(node: GeordiIrNode): NodeStyle {
   const paint = paintStyleFromNode(node);
   return paint ? { paint } : {};
 }
 
-function textNodeStyleFromNode(node: GeordiIrNodeV1): NodeStyle {
+function textNodeStyleFromNode(node: GeordiIrNode): NodeStyle {
   const paint = paintStyleFromNode(node);
   const text = textStyleFromNode(node);
   return paint ? { paint, text } : { text };
 }
 
-function paintStyleFromNode(node: GeordiIrNodeV1): PaintStyle | undefined {
+function paintStyleFromNode(node: GeordiIrNode): PaintStyle | undefined {
   const fill = solidFillFromString(optionalStringProp(node, 'fill'));
   const stroke = solidFillFromString(optionalStringProp(node, 'stroke'));
   const strokeWidth = optionalNumberProp(node, 'strokeWidth');
@@ -173,7 +173,7 @@ function paintStyleFromNode(node: GeordiIrNodeV1): PaintStyle | undefined {
   };
 }
 
-function textStyleFromNode(node: GeordiIrNodeV1): TextStyle {
+function textStyleFromNode(node: GeordiIrNode): TextStyle {
   const lineHeight = optionalNumberProp(node, 'lineHeight');
   const align = textAlignFromProp(node);
 
@@ -191,7 +191,7 @@ function solidFillFromString(value: string | undefined): SolidFill | undefined {
   return value === undefined ? undefined : { type: 'solid', color: value };
 }
 
-function fontWeightFromProp(node: GeordiIrNodeV1): number {
+function fontWeightFromProp(node: GeordiIrNode): number {
   const value = propValue(node.props, 'fontWeight');
   if (value === undefined || value === 'normal') {
     return 400;
@@ -212,7 +212,7 @@ function fontWeightFromProp(node: GeordiIrNodeV1): number {
   );
 }
 
-function textAlignFromProp(node: GeordiIrNodeV1): 'left' | 'center' | 'right' | undefined {
+function textAlignFromProp(node: GeordiIrNode): 'left' | 'center' | 'right' | undefined {
   const value = propValue(node.props, 'align');
   if (value === undefined) {
     return undefined;
@@ -229,7 +229,7 @@ function textAlignFromProp(node: GeordiIrNodeV1): 'left' | 'center' | 'right' | 
   );
 }
 
-function requiredNumberProp(node: GeordiIrNodeV1, key: string): number {
+function requiredNumberProp(node: GeordiIrNode, key: string): number {
   const value = propValue(node.props, key);
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value;
@@ -238,7 +238,7 @@ function requiredNumberProp(node: GeordiIrNodeV1, key: string): number {
   throw new GeordiRuntimeInvalidNodePropsError(node.id, key, 'finite number');
 }
 
-function optionalNumberProp(node: GeordiIrNodeV1, key: string): number | undefined {
+function optionalNumberProp(node: GeordiIrNode, key: string): number | undefined {
   const value = propValue(node.props, key);
   if (value === undefined) {
     return undefined;
@@ -251,7 +251,7 @@ function optionalNumberProp(node: GeordiIrNodeV1, key: string): number | undefin
   throw new GeordiRuntimeInvalidNodePropsError(node.id, key, 'finite number');
 }
 
-function requiredStringProp(node: GeordiIrNodeV1, key: string): string {
+function requiredStringProp(node: GeordiIrNode, key: string): string {
   const value = propValue(node.props, key);
   if (typeof value === 'string') {
     return value;
@@ -260,7 +260,7 @@ function requiredStringProp(node: GeordiIrNodeV1, key: string): string {
   throw new GeordiRuntimeInvalidNodePropsError(node.id, key, 'string');
 }
 
-function optionalStringProp(node: GeordiIrNodeV1, key: string): string | undefined {
+function optionalStringProp(node: GeordiIrNode, key: string): string | undefined {
   const value = propValue(node.props, key);
   if (value === undefined) {
     return undefined;

--- a/packages/runtime-webgl/src/prepareGeordiIr.ts
+++ b/packages/runtime-webgl/src/prepareGeordiIr.ts
@@ -13,6 +13,7 @@ import type {
   SolidFill,
   TextStyle,
 } from '@flyingrobots/geordi-core';
+import { assertSupportedRuntimeProfile } from './profile.js';
 
 export class GeordiRuntimeInvalidIrError extends Error {
   public readonly issues: readonly GeordiIrValidationIssue[];
@@ -49,6 +50,8 @@ export class GeordiRuntimeInvalidNodePropsError extends Error {
 }
 
 export function prepareGeordiIr(ir: GeordiIrV1): PreparedGeordiScene {
+  assertSupportedRuntimeProfile(ir);
+
   const result = validateGeordiIrV1(ir);
   if (!result.ok) {
     throw new GeordiRuntimeInvalidIrError(result.issues);

--- a/packages/runtime-webgl/src/profile.ts
+++ b/packages/runtime-webgl/src/profile.ts
@@ -1,0 +1,64 @@
+import {
+  GEORDI_IR_VERSION,
+  GEORDI_NUMERIC_PROFILE,
+  type GeordiNumericProfile,
+} from '@flyingrobots/geordi-core';
+
+export type GeordiRuntimeNodeKind = 'Rect' | 'Text' | 'Group' | 'Image';
+
+export type GeordiRuntimeVisualFeature =
+  | 'solid-fill'
+  | 'solid-stroke'
+  | 'opacity'
+  | 'corner-radius'
+  | 'text-fill';
+
+export interface GeordiRuntimeProfile {
+  readonly irVersion: typeof GEORDI_IR_VERSION;
+  readonly numericProfile: GeordiNumericProfile;
+  readonly nodeKinds: readonly GeordiRuntimeNodeKind[];
+  readonly visualFeatures: readonly GeordiRuntimeVisualFeature[];
+}
+
+export const GEORDI_WEBGL_RUNTIME_PROFILE: GeordiRuntimeProfile = {
+  irVersion: GEORDI_IR_VERSION,
+  numericProfile: GEORDI_NUMERIC_PROFILE,
+  nodeKinds: ['Rect', 'Text', 'Group', 'Image'],
+  visualFeatures: ['solid-fill', 'solid-stroke', 'opacity', 'corner-radius', 'text-fill'],
+};
+
+export class GeordiRuntimeUnsupportedProfileError extends Error {
+  public readonly requirement: string;
+  public readonly supported: string;
+
+  constructor(requirement: string, supported: string) {
+    super('Unsupported runtime profile');
+    this.name = new.target.name;
+    this.requirement = requirement;
+    this.supported = supported;
+  }
+}
+
+interface RuntimeProfileRequirement {
+  readonly irVersion: string;
+  readonly numericProfile?: string;
+}
+
+export function assertSupportedRuntimeProfile(
+  ir: RuntimeProfileRequirement,
+  profile: GeordiRuntimeProfile = GEORDI_WEBGL_RUNTIME_PROFILE,
+): void {
+  if (ir.irVersion !== profile.irVersion) {
+    throw new GeordiRuntimeUnsupportedProfileError(
+      `irVersion=${ir.irVersion}`,
+      `irVersion=${profile.irVersion}`,
+    );
+  }
+
+  if (ir.numericProfile !== profile.numericProfile) {
+    throw new GeordiRuntimeUnsupportedProfileError(
+      `numericProfile=${String(ir.numericProfile)}`,
+      `numericProfile=${profile.numericProfile}`,
+    );
+  }
+}

--- a/packages/runtime-webgl/src/utils.ts
+++ b/packages/runtime-webgl/src/utils.ts
@@ -2,7 +2,7 @@
  * Utility functions for Geordi rendering
  */
 
-import type { GeordiIrV1, PreparedGeordiScene } from '@flyingrobots/geordi-core';
+import type { GeordiIr, PreparedGeordiScene } from '@flyingrobots/geordi-core';
 import { GeordiWebGLRenderer } from './WebGLRenderer.js';
 import { prepareGeordiIr } from './prepareGeordiIr.js';
 
@@ -22,7 +22,7 @@ export function renderPreparedSceneToCanvas(scene: PreparedGeordiScene): HTMLCan
 }
 
 /** Render public `geordi-ir/1` to a canvas element. */
-export function renderGeordiToCanvas(ir: GeordiIrV1): HTMLCanvasElement {
+export function renderGeordiToCanvas(ir: GeordiIr): HTMLCanvasElement {
   return renderPreparedSceneToCanvas(prepareGeordiIr(ir));
 }
 

--- a/packages/schema-graphql/src/directives/geordiDirectives.ts
+++ b/packages/schema-graphql/src/directives/geordiDirectives.ts
@@ -75,7 +75,7 @@ export const geordiStyleDirective = new GraphQLDirective({
   },
 });
 
-export const GEORDI_V1_DIRECTIVES: readonly GraphQLDirective[] = [
+export const GEORDI_DIRECTIVES: readonly GraphQLDirective[] = [
   geordiSceneDirective,
   geordiNodeDirective,
   geordiBindDirective,
@@ -138,6 +138,6 @@ export function withGeordiDirectives(baseSchemaConfig: {
 }): GraphQLSchema {
   return new GraphQLSchema({
     ...baseSchemaConfig,
-    directives: [...GEORDI_V1_DIRECTIVES],
+    directives: [...GEORDI_DIRECTIVES],
   });
 }

--- a/packages/schema-graphql/src/index.ts
+++ b/packages/schema-graphql/src/index.ts
@@ -1,3 +1,3 @@
-export * from './directives/v1.js';
+export * from './directives/geordiDirectives.js';
 export { graphqlToCanonicalAst } from './adapter.js';
 export type { GraphqlToCanonicalAst } from './adapter.js';

--- a/packages/schema-graphql/src/parse/extractNodes.ts
+++ b/packages/schema-graphql/src/parse/extractNodes.ts
@@ -1,6 +1,6 @@
 import { ParseError, GeordiErrorCode, parseJsonValue } from '@flyingrobots/geordi-compiler-core';
 import type { Diagnostic, JsonObject, JsonValue, NodeKind, SourceRef } from '@flyingrobots/geordi-compiler-core';
-import { isGeordiNodeKind } from '../directives/v1.js';
+import { isGeordiNodeKind } from '../directives/geordiDirectives.js';
 import {
   readOptionalBooleanArg,
   readOptionalFloatArg,

--- a/packages/schema-graphql/src/parse/extractScene.ts
+++ b/packages/schema-graphql/src/parse/extractScene.ts
@@ -1,7 +1,7 @@
 import { type DocumentNode, type ObjectTypeDefinitionNode, Kind } from 'graphql';
 import { ParseError, GeordiErrorCode } from '@flyingrobots/geordi-compiler-core';
 import type { Diagnostic, SourceRef } from '@flyingrobots/geordi-compiler-core';
-import { validateGeordiDirectiveVersion } from '../directives/v1.js';
+import { validateGeordiDirectiveVersion } from '../directives/geordiDirectives.js';
 import {
   readOptionalStringArg,
   readRequiredIntArg,

--- a/packages/schema-graphql/test/e2e.terminal.test.ts
+++ b/packages/schema-graphql/test/e2e.terminal.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import { compile, GeordiErrorCode, parseJsonValue } from '@flyingrobots/geordi-compiler-core';
 import { graphqlToCanonicalAst } from '../src/index';
-import type { CompilerInput, CompileResult, GeordiIrV1, ParseInputDeps } from '@flyingrobots/geordi-compiler-core';
+import type { CompilerInput, CompileResult, GeordiIr, ParseInputDeps } from '@flyingrobots/geordi-compiler-core';
 
 const TERMINAL_SDL = `
 type Terminal @geordi_scene(v: "1", width: 800, height: 600) {
@@ -35,7 +35,7 @@ function makeInput(sdl: string, filename = 'terminal.graphql'): CompilerInput {
     source: sdl,
     filename,
     options: {
-      target: 'geordi-ir-v1',
+      target: 'geordi-ir',
       emit: { irJson: true, tsTypes: true },
       strict: true,
       failOnWarnings: false,
@@ -49,8 +49,8 @@ function irContent(result: CompileResult): string {
   return String(artifact.content);
 }
 
-function parseIr(result: CompileResult): GeordiIrV1 {
-  return parseJsonValue(irContent(result)) as GeordiIrV1;
+function parseIr(result: CompileResult): GeordiIr {
+  return parseJsonValue(irContent(result)) as GeordiIr;
 }
 
 describe('e2e: Terminal SDL fixture', () => {

--- a/packages/wesley-generator/src/GeordiGeneratorPlugin.ts
+++ b/packages/wesley-generator/src/GeordiGeneratorPlugin.ts
@@ -83,7 +83,7 @@ export class GeordiGeneratorPlugin {
       source: sdl,
       filename: 'schema.graphql',
       options: {
-        target: 'geordi-ir-v1',
+        target: 'geordi-ir',
         emit: {
           irJson: true,
           tsTypes: true,

--- a/packages/wesley-generator/src/index.test.ts
+++ b/packages/wesley-generator/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { parseJsonValue } from '@flyingrobots/geordi-compiler-core';
-import type { GeordiIrV1 } from '@flyingrobots/geordi-compiler-core';
+import type { GeordiIr } from '@flyingrobots/geordi-compiler-core';
 import { GeordiGenerationFailedError, GeordiGeneratorPlugin } from './index';
 
 const MINIMAL_SDL = `
@@ -69,7 +69,7 @@ describe('wesley-generator public API', () => {
       'types.ts',
     ]);
 
-    const ir = parseJsonValue(stringArtifact(output, 'scene.geordi.json')) as GeordiIrV1;
+    const ir = parseJsonValue(stringArtifact(output, 'scene.geordi.json')) as GeordiIr;
     expect(ir.irVersion).toBe('geordi-ir/1');
     expect(ir.scene.width).toBe(320);
     expect(ir.scene.height).toBe(200);

--- a/scripts/smoke-package-exports.mjs
+++ b/scripts/smoke-package-exports.mjs
@@ -1,13 +1,13 @@
 import { readFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 
-import { parseJsonValue } from '../packages/compiler-core/dist/index.js';
+import { parseJsonValue } from '../packages/core/dist/index.js';
 
 const checks = [
   {
     packageName: '@flyingrobots/geordi-core',
     packageDir: 'packages/core',
-    exports: ['isGeordiScene', 'isRectNode'],
+    exports: ['GEORDI_NUMERIC_PROFILE', 'isGeordiScene', 'isRectNode', 'parseJsonValue'],
   },
   {
     packageName: '@flyingrobots/geordi-compiler-core',
@@ -22,7 +22,7 @@ const checks = [
   {
     packageName: '@flyingrobots/geordi-runtime-webgl',
     packageDir: 'packages/runtime-webgl',
-    exports: ['GeordiWebGLRenderer', 'renderGeordiToCanvas'],
+    exports: ['GEORDI_WEBGL_RUNTIME_PROFILE', 'GeordiWebGLRenderer', 'renderGeordiToCanvas'],
   },
   {
     packageName: '@flyingrobots/geordi-wesley-generator',


### PR DESCRIPTION
## Summary

Defines Geordi's v0 numeric determinism contract and moves canonical JSON handling to the core package boundary.

- Added the core numeric profile `geordi-finite-binary64/1` with finite-number guards and custom error types.
- Added `numericProfile` to `GeordiIrV1`, compiler-emitted IR, and compiler receipts.
- Added a WebGL runtime capability profile and fail-loud rejection for unsupported IR versions or numeric profiles.
- Moved canonical JSON parse/stringify/normalization into `@flyingrobots/geordi-core`, keeping a compiler-core compatibility adapter.
- Updated docs, backlog, status, changelog, and export smoke coverage.

## Why

The repo needed a hard, explicit answer for deterministic graphics numbers and a single canonical JSON boundary. v0 now states that Geordi accepts finite binary64 numbers without hidden fixed-point scaling or rounding; future fixed-point or matrix-specific arithmetic profiles can be introduced as named profiles rather than implicit behavior.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` - 165 tests passed across core, compiler-core, runtime-webgl, schema-graphql, and wesley-generator
- `pnpm test:docs`
- `pnpm test:package-names`
- `pnpm test:repo-sludge`
- `pnpm test:placeholders`
- `pnpm test:exports`

## Commit

- `d5d36db` - `Implement core numeric profile and JSON port`
