### PR TITLE
[codex] Add source maps and deterministic diagnostics

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -157,12 +157,14 @@ with an empty `props` block. This is an edge case in `TypeEmitter.emitKindInterf
 
 ### `parseInput.ts` — surface `E_INPUT_INVALID_SDL` source location to diagnostics
 **Issue**: [#7](https://github.com/flyingrobots/geordi/issues/7)
-**Status**: Resolved by the typed diagnostics transport P0 work.
+**Status**: Resolved by the typed diagnostics transport P0 work. GitHub issue #7 is closed.
 
 When `parseGraphql` throws a `ParseError` with `E_INPUT_INVALID_SDL`, `parseInput.ts` currently
 catches it and converts to a diagnostic but loses the GraphQL source location (`line`, `column`)
 from the original `ParseError`. Propagate the location into `Diagnostic.details` so callers can
 report precise SDL error positions to users.
+
+Open GitHub-backed backlog after this reconciliation: #2, #3, #4, #5, and #6 remain active.
 
 ---
 

--- a/BEARING.md
+++ b/BEARING.md
@@ -47,6 +47,12 @@ Completed:
   identities remain explicit through values such as `irVersion: "geordi-ir/1"`.
 - GitHub issue #7 was closed after confirmation that typed diagnostics transport already preserves
   invalid-SDL diagnostic location details.
+- Source locations now have a canonical compiler-core model shared by AST `SourceRef` and
+  diagnostics. GraphQL extraction preserves source spans and offsets.
+- `scene.geordi.map.json` is emitted alongside IR JSON and receipts include `sourceMapHash`.
+- Compiler-core exposes a deterministic diagnostic formatter, and the Wesley generator uses it for
+  stable logging.
+- Root `pnpm wesley` shells out to the installed Wesley CLI.
 
 Still true:
 
@@ -55,14 +61,15 @@ Still true:
 
 ## Immediate Moves
 
-1. Add source maps and diagnostic UX improvements.
-2. Define the next explicit feature/capability profile beyond the v0 baseline.
+1. Define the next explicit feature/capability profile beyond the v0 baseline.
+2. Keep source-map and diagnostic formatter behavior wired into future CLI/Wesley entrypoints.
 3. Keep dependency hygiene clean; there are no open PRs at the time this bearing was refreshed.
 
 ## Recommended P0 Order
 
-1. Add source maps and diagnostic UX improvements.
-2. Define the next feature/capability profile beyond the v0 baseline.
+1. Define the next feature/capability profile beyond the v0 baseline.
+2. Decide whether Wesley modernization should target `wesley-cli`/`wesley-core` 0.0.5 through a
+   CLI boundary, Rust workspace boundary, or future npm/WASM boundary.
 
 ## Dependency Work
 

--- a/BEARING.md
+++ b/BEARING.md
@@ -1,8 +1,8 @@
 # Geordi Bearing
 
-**Date**: 2026-05-22
-**Branch baseline**: `main` at `c4597a6`
-**Current head when written**: `c4597a6`
+**Date**: 2026-05-23
+**Branch baseline**: `main` at `2dcf510`
+**Current head when written**: `2dcf510`
 
 This file is the short-term operating map. Product rationale remains in
 [`docs/V0_DESIGN_LAWS.md`](./docs/V0_DESIGN_LAWS.md); detailed work items remain in
@@ -42,6 +42,11 @@ Completed:
   behavior and custom JSON error types.
 - `geordi-ir/1` declares `numericProfile: "geordi-finite-binary64/1"`; compiler receipts include
   that profile, and runtime-webgl rejects unsupported profile requirements before rendering.
+- Public TypeScript API names are de-versioned for the current IR surface: use `GeordiIr`,
+  `validateGeordiIr()`, `isGeordiIr()`, and compiler target `geordi-ir`; payload/profile
+  identities remain explicit through values such as `irVersion: "geordi-ir/1"`.
+- GitHub issue #7 was closed after confirmation that typed diagnostics transport already preserves
+  invalid-SDL diagnostic location details.
 
 Still true:
 
@@ -50,12 +55,9 @@ Still true:
 
 ## Immediate Moves
 
-1. Finish dependency hygiene:
-   - GitHub Actions Dependabot PR #10 was mergeable and has been merged.
-   - Conflicting npm Dependabot PR #8 should be recreated by Dependabot before any manual lockfile
-     work.
-2. Add source maps and diagnostic UX improvements.
-3. Define the next explicit feature/capability profile beyond the v0 baseline.
+1. Add source maps and diagnostic UX improvements.
+2. Define the next explicit feature/capability profile beyond the v0 baseline.
+3. Keep dependency hygiene clean; there are no open PRs at the time this bearing was refreshed.
 
 ## Recommended P0 Order
 
@@ -64,10 +66,7 @@ Still true:
 
 ## Dependency Work
 
-Open Dependabot state when this was written:
+Open Dependabot state when this was refreshed: none.
 
-- PR #10, GitHub Actions group: merged.
-- PR #8, npm/yarn group: stale/conflicting; Dependabot has been asked to recreate it.
-
-Manual lockfile conflict resolution should be avoided unless Dependabot cannot regenerate a clean
-branch.
+Manual lockfile conflict resolution should still be avoided unless Dependabot cannot regenerate a
+clean branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@
 - **Public API**: De-version the current IR TypeScript surface (`GeordiIr`,
   `validateGeordiIr()`, `isGeordiIr()`) and compiler target (`geordi-ir`) while preserving
   `irVersion: "geordi-ir/1"` as the serialized contract identity.
+- **Root scripts**: Add `pnpm wesley` as a thin shell-out to the installed `wesley` CLI.
+- **`@flyingrobots/geordi-compiler-core`**: Add a canonical source-location model shared by AST
+  `SourceRef` and diagnostics, including optional spans and offsets.
+- **`@flyingrobots/geordi-schema-graphql`**: Preserve GraphQL source spans and byte offsets for
+  scene, node, and directive-argument diagnostics.
+- **`@flyingrobots/geordi-compiler-core`**: Add a deterministic diagnostic formatter with stable
+  source-span rendering and canonical JSON details.
+- **`@flyingrobots/geordi-compiler-core`**: Emit `scene.geordi.map.json` source maps alongside IR
+  JSON, mapping IR node IDs back to source locations and adding `sourceMapHash` to receipts.
 - **`@flyingrobots/geordi-compiler-core`**: Semantic validation engine — `validateCanonicalAst()` with two-tier rule registry; Tier 1 (structural: `sceneDimensions`, `nodeKindValid`, `duplicateId`, `danglingRef`, `cycleDetection`) gates Tier 2 (semantic: `requiredProps` per NodeKind); iterative Kahn's cycle detection passes 10k-node chains without stack overflow
 - **`@flyingrobots/geordi-compiler-core`**: Deterministic IR emitter — `emitGeordiIrArtifact()` replaces stub; two-phase topological sort (Kahn's on `parentId` DAG, tie-broken `zIndex ASC → kind ASC → id ASC` bytewise); strips `sourceRef` and `__typename`
 - **`@flyingrobots/geordi-compiler-core`**: Determinism certificate — `emitReceiptArtifact()` emits `scene.geordi.json.receipt` alongside IR containing `comparatorVersion`, `inputHash` (SHA-256 of `input.source`), `irHash` (SHA-256 of the emitted IR), `irHashAlg` (`"sha256"`), `irVersion`, and `rulesetFingerprint` (SHA-256 of sorted rule IDs)
@@ -68,6 +77,10 @@
   spelling, and no hidden fixed-point scaling.
 - **`@flyingrobots/geordi-runtime-webgl`**: add runtime profile export and unsupported profile
   rejection coverage.
+- **`@flyingrobots/geordi-compiler-core`**: add source-location model, diagnostic formatter, and
+  source-map artifact coverage.
+- **`@flyingrobots/geordi-schema-graphql`**: add exact GraphQL source-span tests and an e2e source
+  map assertion from IR node ID back to SDL field location.
 - **`@flyingrobots/geordi-wesley-generator`**: add behavior contract tests for `plan()`, successful SDL-to-artifacts generation, and custom failure errors on bad SDL
 - **`@flyingrobots/geordi-runtime-webgl`**: add canvas/context mock behavior tests for rendering the prepared scene contract and context-unavailable failure
 - **`@flyingrobots/geordi-compiler-core`**: 74 new tests across sprint 3 — first batch: `stableStringify` (22), `parseInput` table-driven (9), `determinism` (3) → 36 tests; second batch: `validateAst` (15), `emitTypes` (19), `determinism` +4, `compile.golden` +3 → total 79 tests

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,7 +53,7 @@ validateCanonicalAst() [semantic checks]
   ↓
 emitGeordiIr() + emitTypes() + emitSchema()
   ↓
-Artifacts (scene.geordi.json, types.ts, etc.)
+Artifacts (scene.geordi.json, scene.geordi.map.json, types.ts, etc.)
 ```
 
 ### Phase 1: Parse
@@ -84,6 +84,7 @@ Artifacts (scene.geordi.json, types.ts, etc.)
 - **Output**: ArtifactMap
 - **Emitters**:
   - `emitGeordiIr()` → scene.geordi.json
+  - source map emission → scene.geordi.map.json
   - `emitTypes()` → types.ts
   - `emitSchema()` → scene.geordi.schema.json (optional)
 
@@ -118,6 +119,7 @@ See [`docs/ERROR_CODES.md`](./ERROR_CODES.md) for complete taxonomy.
 
 - **AST version**: `astVersion: "1"` (canonical AST)
 - **IR version**: `irVersion: "geordi-ir/1"` (output format)
+- **Source map version**: `version: "geordi-source-map/1"` (IR node ID to source location map)
 - **Numeric profile**: `numericProfile: "geordi-finite-binary64/1"` (finite binary64 graphics numbers)
 - **Directive version**: `v: "1"` (GraphQL directives)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -22,10 +22,12 @@ Pure, framework-agnostic compilation engine.
 - Compile orchestrator with parse, canonicalize, validate, and emit phases.
 - GraphQL SDL and canonical JSON input paths.
 - Uses the core-owned deterministic JSON port for canonical parse/stringify boundaries.
-- Deterministic IR, receipt, and TypeScript type emission.
+- Deterministic IR, receipt, source-map, and TypeScript type emission.
 - IR and receipt emission declare the v0 numeric profile.
 - Current public IR API names are `GeordiIr`, `validateGeordiIr()`, and `isGeordiIr()`; versioning
   remains in serialized contract values such as `irVersion: "geordi-ir/1"`.
+- Canonical source-location model shared by AST source refs and diagnostics.
+- Deterministic diagnostic formatter for stable CLI/adapter output.
 - Post-build public export smoke coverage.
 
 #### `@flyingrobots/geordi-schema-graphql`
@@ -35,6 +37,7 @@ GraphQL SDL to canonical AST adapter.
 - Directive definitions with an explicit directive version contract.
 - GraphQL parser wrapper with source naming.
 - Scene and node extraction.
+- Exact GraphQL source spans and offsets for scene, node, and directive argument diagnostics.
 - Canonical AST transform.
 - End-to-end SDL compilation coverage through compiler-core.
 
@@ -45,7 +48,8 @@ Wesley GeneratorPlugin adapter scaffold.
 - Plugin lifecycle shape: `apiVersion`, `name`, `plan`, `generate`.
 - Compiler adapter injection via `graphqlToCanonicalAst`.
 - Public entrypoint contract test.
-- Still needs behavior coverage for `plan()` and `generate()`.
+- Root `pnpm wesley` script shells out to the installed Wesley CLI.
+- Behavior coverage for `plan()`, successful generation, and custom failure errors.
 
 #### `@flyingrobots/geordi-core`
 
@@ -92,12 +96,12 @@ Latest full local gate during the core IR runtime-contract work:
 
 | Package | Tests | Status |
 | --- | ---: | --- |
-| `@flyingrobots/geordi-compiler-core` | 73 | Green |
-| `@flyingrobots/geordi-schema-graphql` | 51 | Green |
+| `@flyingrobots/geordi-compiler-core` | 82 | Green |
+| `@flyingrobots/geordi-schema-graphql` | 55 | Green |
 | `@flyingrobots/geordi-core` | 26 | Green |
 | `@flyingrobots/geordi-runtime-webgl` | 12 | Green |
 | `@flyingrobots/geordi-wesley-generator` | 3 | Green |
-| **Total package tests** | **165** | Green |
+| **Total package tests** | **178** | Green |
 
 Additional gates:
 
@@ -113,8 +117,8 @@ Additional gates:
 
 Immediate:
 
-1. Add source maps and diagnostic UX improvements.
-2. Define the next feature/capability profile beyond the v0 baseline.
+1. Define the next feature/capability profile beyond the v0 baseline.
+2. Keep source-map and diagnostic formatter behavior wired into future CLI/Wesley entrypoints.
 3. Keep dependency hygiene clean; there are no open PRs at this refresh point.
 
 Short term:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,8 @@
 # Geordi Compiler Status
 
-**Date**: 2026-05-22
+**Date**: 2026-05-23
 **Version**: 0.1.0-dev
-**Milestone**: First stabilization pass merged
+**Milestone**: Source-map and diagnostic UX work starting from `main` at `2dcf510`
 
 See [`../BEARING.md`](../BEARING.md) for the current operating map.
 
@@ -24,6 +24,8 @@ Pure, framework-agnostic compilation engine.
 - Uses the core-owned deterministic JSON port for canonical parse/stringify boundaries.
 - Deterministic IR, receipt, and TypeScript type emission.
 - IR and receipt emission declare the v0 numeric profile.
+- Current public IR API names are `GeordiIr`, `validateGeordiIr()`, and `isGeordiIr()`; versioning
+  remains in serialized contract values such as `irVersion: "geordi-ir/1"`.
 - Post-build public export smoke coverage.
 
 #### `@flyingrobots/geordi-schema-graphql`
@@ -53,6 +55,7 @@ Core domain package.
 - Canonical JSON port with deterministic parse/stringify/normalize behavior and custom JSON
   errors.
 - v0 numeric profile constant `geordi-finite-binary64/1` and graphics-number helpers.
+- Current `GeordiIr` structural types and validation for the `geordi-ir/1` payload contract.
 - Draw-ready runtime scene aliases named `PreparedGeordiScene` and `PreparedGeordiNode`.
 - Compatibility aliases for the older scene names remain during the v0.1 migration.
 
@@ -110,11 +113,9 @@ Additional gates:
 
 Immediate:
 
-1. Keep dependency hygiene clean.
-   - GitHub Actions Dependabot update PR #10 has been merged.
-   - npm/yarn Dependabot PR #8 was stale and conflicting; Dependabot has been asked to recreate it.
-2. Add source maps and diagnostic UX improvements.
-3. Define the next feature/capability profile beyond the v0 baseline.
+1. Add source maps and diagnostic UX improvements.
+2. Define the next feature/capability profile beyond the v0 baseline.
+3. Keep dependency hygiene clean; there are no open PRs at this refresh point.
 
 Short term:
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "pnpm lint:root && turbo run lint",
     "lint:root": "eslint . --max-warnings 0",
     "typecheck": "turbo run typecheck",
+    "wesley": "wesley",
     "clean": "turbo run clean && rm -rf node_modules",
     "changeset": "changeset",
     "version-packages": "changeset version",

--- a/packages/compiler-core/src/compile/compile.ts
+++ b/packages/compiler-core/src/compile/compile.ts
@@ -18,7 +18,15 @@ import { parseInputToCanonicalAst, type ParseInputDeps } from './parseInput.js';
 import { HASH_ALGORITHM } from '../canonical/hashing.js';
 import { normalizeCanonicalAst } from '../canonical/normalizeAst.js';
 import { validateCanonicalAst, VALIDATION_RULE_IDS } from './validateAst.js';
-import { emitGeordiIrArtifact, emitReceiptArtifact, IR_ARTIFACT_KEY, IR_RECEIPT_KEY, IR_VERSION } from './emitIr.js';
+import {
+  emitGeordiIrArtifact,
+  emitReceiptArtifact,
+  emitSourceMapArtifact,
+  IR_ARTIFACT_KEY,
+  IR_RECEIPT_KEY,
+  IR_VERSION,
+  SOURCE_MAP_ARTIFACT_KEY,
+} from './emitIr.js';
 import { emitTypesArtifact } from './emitTypes.js';
 
 const DEFAULT_OPTIONS: CompileOptions = {
@@ -77,9 +85,16 @@ export async function compile(input: CompilerInput, deps?: ParseInputDeps): Prom
     }
     if (options.emit.irJson && canonicalAst) {
       const irArtifact = emitGeordiIrArtifact(canonicalAst);
+      const sourceMapArtifact = emitSourceMapArtifact(canonicalAst);
       artifacts[IR_ARTIFACT_KEY] = irArtifact;
+      artifacts[SOURCE_MAP_ARTIFACT_KEY] = sourceMapArtifact;
 
-      artifacts[IR_RECEIPT_KEY] = emitReceiptArtifact(input, irArtifact.content as string, VALIDATION_RULE_IDS);
+      artifacts[IR_RECEIPT_KEY] = emitReceiptArtifact(
+        input,
+        irArtifact.content as string,
+        sourceMapArtifact.content as string,
+        VALIDATION_RULE_IDS,
+      );
     }
     if (options.emit.tsTypes && canonicalAst) {
       artifacts['types.ts'] = emitTypesArtifact(canonicalAst);

--- a/packages/compiler-core/src/compile/emitIr.ts
+++ b/packages/compiler-core/src/compile/emitIr.ts
@@ -17,6 +17,8 @@ export const IR_VERSION = GEORDI_IR_VERSION;
 export const IR_ARTIFACT_KEY = GEORDI_IR_ARTIFACT_KEY;
 export const IR_RECEIPT_KEY = GEORDI_IR_RECEIPT_KEY;
 export const NUMERIC_PROFILE = GEORDI_NUMERIC_PROFILE;
+export const SOURCE_MAP_ARTIFACT_KEY = 'scene.geordi.map.json' as const;
+export const SOURCE_MAP_VERSION = 'geordi-source-map/1' as const;
 
 /**
  * Phase 1: Topological sort by parentId DAG.
@@ -26,7 +28,7 @@ export const NUMERIC_PROFILE = GEORDI_NUMERIC_PROFILE;
  * sourceRef and __typename are stripped.
  */
 export function emitGeordiIrArtifact(ast: CanonicalSceneAst): Artifact {
-  const sorted = topoSort(ast);
+  const sorted = topoSortNodes(ast).map((node) => sanitize(node));
 
   const content = stringifyCanonicalJson(
     {
@@ -48,15 +50,43 @@ export function emitGeordiIrArtifact(ast: CanonicalSceneAst): Artifact {
   };
 }
 
+export function emitSourceMapArtifact(ast: CanonicalSceneAst): Artifact {
+  const nodes = topoSortNodes(ast)
+    .filter((node) => node.sourceRef !== undefined)
+    .map((node) => ({
+      id: node.id,
+      source: node.sourceRef,
+    }));
+
+  const content = stringifyCanonicalJson(
+    {
+      irVersion: IR_VERSION,
+      nodes,
+      sourceFormat: ast.metadata?.sourceFormat,
+      version: SOURCE_MAP_VERSION,
+    },
+    { space: 2 },
+  );
+
+  return {
+    path: SOURCE_MAP_ARTIFACT_KEY,
+    content,
+    mediaType: 'application/json',
+    encoding: 'utf8',
+  };
+}
+
 export const IR_HASH_ALG = GEORDI_IR_HASH_ALGORITHM;
 
 export function emitReceiptArtifact(
   input: CompilerInput,
   irContent: string,
+  sourceMapContent: string,
   ruleIds: readonly string[],
 ): Artifact {
   const inputHash = hashString(input.source);
   const irHash = hashString(irContent);
+  const sourceMapHash = hashString(sourceMapContent);
   const rulesetFingerprint = hashString([...ruleIds].sort().join('\n'));
 
   const content = stringifyCanonicalJson(
@@ -68,6 +98,8 @@ export function emitReceiptArtifact(
       irVersion: IR_VERSION,
       numericProfile: NUMERIC_PROFILE,
       rulesetFingerprint,
+      sourceMapHash,
+      sourceMapHashAlg: IR_HASH_ALG,
     },
     { space: 2 },
   );
@@ -103,7 +135,7 @@ function sanitize(node: CanonicalSceneAst['nodes'][number]): SanitizedNode {
   return clean;
 }
 
-function topoSort(ast: CanonicalSceneAst): SanitizedNode[] {
+function topoSortNodes(ast: CanonicalSceneAst): CanonicalSceneAst['nodes'][number][] {
   const nodes = ast.nodes;
   if (nodes.length === 0) return [];
 
@@ -137,7 +169,7 @@ function topoSort(ast: CanonicalSceneAst): SanitizedNode[] {
   }
   sortReady(ready);
 
-  const result: SanitizedNode[] = [];
+  const result: CanonicalSceneAst['nodes'][number][] = [];
 
   // Use an index pointer instead of shift() to avoid O(n) array reindexing per dequeue.
   // Newly-ready children are collected per iteration, sorted once, then merged into the
@@ -145,7 +177,7 @@ function topoSort(ast: CanonicalSceneAst): SanitizedNode[] {
   let qi = 0;
   while (qi < ready.length) {
     const node = ready[qi++];
-    result.push(sanitize(node));
+    result.push(node);
 
     const newlyReady: CanonicalSceneAst['nodes'][number][] = [];
     for (const child of children.get(node.id) ?? []) {
@@ -175,7 +207,7 @@ function topoSort(ast: CanonicalSceneAst): SanitizedNode[] {
   }
   sortReady(remaining);
   for (const node of remaining) {
-    result.push(sanitize(node));
+    result.push(node);
   }
 
   return result;

--- a/packages/compiler-core/src/diagnostics/formatDiagnostics.ts
+++ b/packages/compiler-core/src/diagnostics/formatDiagnostics.ts
@@ -1,0 +1,47 @@
+import type { Diagnostic, SourceLocation } from '../types/index.js';
+import { stringifyCanonicalJson } from '../ports/json.js';
+
+export interface DiagnosticFormatOptions {
+  readonly includeDetails?: boolean;
+}
+
+const DEFAULT_FORMAT_OPTIONS: Required<DiagnosticFormatOptions> = {
+  includeDetails: true,
+};
+
+export function formatDiagnostic(
+  diagnostic: Diagnostic,
+  options: DiagnosticFormatOptions = {},
+): string {
+  const resolvedOptions = { ...DEFAULT_FORMAT_OPTIONS, ...options };
+  const location = diagnostic.location ? `${formatSourceLocation(diagnostic.location)} ` : '';
+  const lines = [
+    `${diagnostic.severity} ${diagnostic.code} ${location}${diagnostic.message}`,
+  ];
+
+  if (diagnostic.hint) {
+    lines.push(`hint: ${diagnostic.hint}`);
+  }
+
+  if (resolvedOptions.includeDetails && diagnostic.details) {
+    lines.push(`details: ${stringifyCanonicalJson(diagnostic.details)}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function formatDiagnostics(
+  diagnostics: readonly Diagnostic[],
+  options: DiagnosticFormatOptions = {},
+): string {
+  return diagnostics.map((diagnostic) => formatDiagnostic(diagnostic, options)).join('\n\n');
+}
+
+export function formatSourceLocation(location: SourceLocation): string {
+  const start = `${location.file}:${location.line}:${location.column}`;
+  if (location.endLine === undefined || location.endColumn === undefined) {
+    return start;
+  }
+
+  return `${start}-${location.endLine}:${location.endColumn}`;
+}

--- a/packages/compiler-core/src/diagnostics/index.ts
+++ b/packages/compiler-core/src/diagnostics/index.ts
@@ -1,0 +1,6 @@
+export {
+  formatDiagnostic,
+  formatDiagnostics,
+  formatSourceLocation,
+} from './formatDiagnostics.js';
+export type { DiagnosticFormatOptions } from './formatDiagnostics.js';

--- a/packages/compiler-core/src/index.ts
+++ b/packages/compiler-core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './types/index.js';
 export * from './errors/index.js';
+export * from './diagnostics/index.js';
 export * from './ports/json.js';
 export { compile } from './compile/compile.js';
 export type { GraphqlToCanonicalAst, ParseInputDeps } from './compile/parseInput.js';

--- a/packages/compiler-core/src/types/ast.ts
+++ b/packages/compiler-core/src/types/ast.ts
@@ -1,4 +1,5 @@
 import type { JsonObject, JsonPrimitive, JsonValue } from './json.js';
+import type { SourceLocation } from './source.js';
 
 export interface CanonicalSceneAst extends JsonObject {
   kind: 'Scene';
@@ -21,11 +22,7 @@ export interface Scene extends JsonObject {
 
 export type NodeKind = 'Rect' | 'Text' | 'Image' | 'Group' | 'Line' | 'Ellipse' | 'Path';
 
-export interface SourceRef extends JsonObject {
-  file: string;
-  line: number;
-  column: number;
-}
+export type SourceRef = SourceLocation;
 
 export interface ShadowProps extends JsonObject {
   x?: number;

--- a/packages/compiler-core/src/types/diagnostics.ts
+++ b/packages/compiler-core/src/types/diagnostics.ts
@@ -1,14 +1,7 @@
 import type { JsonObject } from './json.js';
+import type { SourceLocation } from './source.js';
 
 export type DiagnosticSeverity = 'error' | 'warning' | 'info';
-
-export interface SourceLocation {
-  file: string;
-  line: number; // 1-based
-  column: number; // 1-based
-  endLine?: number;
-  endColumn?: number;
-}
 
 export interface Diagnostic {
   code: string; // e.g. GEORDI_E_SCENE_MISSING

--- a/packages/compiler-core/src/types/index.ts
+++ b/packages/compiler-core/src/types/index.ts
@@ -4,3 +4,4 @@ export * from './compiler.js';
 export * from './diagnostics.js';
 export * from './ir.js';
 export * from './json.js';
+export * from './source.js';

--- a/packages/compiler-core/src/types/source.ts
+++ b/packages/compiler-core/src/types/source.ts
@@ -1,0 +1,93 @@
+import type { JsonObject } from './json.js';
+
+export const INLINE_SOURCE_FILE = '<inline>' as const;
+
+export interface SourceLocation extends JsonObject {
+  file: string;
+  line: number;
+  column: number;
+  endLine?: number;
+  endColumn?: number;
+  offset?: number;
+  endOffset?: number;
+}
+
+export interface SourceLocationInput {
+  file?: string;
+  line?: number;
+  column?: number;
+  endLine?: number;
+  endColumn?: number;
+  offset?: number;
+  endOffset?: number;
+}
+
+export class InvalidSourceLocationError extends Error {
+  public readonly field: string;
+
+  constructor(field: string) {
+    super('Invalid source location');
+    this.name = new.target.name;
+    this.field = field;
+  }
+}
+
+export function createSourceLocation(input: SourceLocationInput = {}): SourceLocation {
+  const file = input.file && input.file.length > 0 ? input.file : INLINE_SOURCE_FILE;
+  const line = input.line ?? 1;
+  const column = input.column ?? 1;
+
+  requirePositiveInteger(line, 'line');
+  requirePositiveInteger(column, 'column');
+
+  const location: SourceLocation = { file, line, column };
+
+  if (input.endLine !== undefined || input.endColumn !== undefined) {
+    if (input.endLine === undefined) {
+      throw new InvalidSourceLocationError('endLine');
+    }
+    if (input.endColumn === undefined) {
+      throw new InvalidSourceLocationError('endColumn');
+    }
+
+    requirePositiveInteger(input.endLine, 'endLine');
+    requirePositiveInteger(input.endColumn, 'endColumn');
+
+    if (
+      input.endLine < line ||
+      (input.endLine === line && input.endColumn < column)
+    ) {
+      throw new InvalidSourceLocationError('endColumn');
+    }
+
+    location.endLine = input.endLine;
+    location.endColumn = input.endColumn;
+  }
+
+  if (input.offset !== undefined) {
+    requireNonNegativeInteger(input.offset, 'offset');
+    location.offset = input.offset;
+  }
+
+  if (input.endOffset !== undefined) {
+    requireNonNegativeInteger(input.endOffset, 'endOffset');
+    if (input.offset !== undefined && input.endOffset < input.offset) {
+      throw new InvalidSourceLocationError('endOffset');
+    }
+    location.endOffset = input.endOffset;
+  }
+
+  return location;
+}
+
+function requirePositiveInteger(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new InvalidSourceLocationError(field);
+  }
+}
+
+function requireNonNegativeInteger(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new InvalidSourceLocationError(field);
+  }
+}

--- a/packages/compiler-core/test/compile.golden.test.ts
+++ b/packages/compiler-core/test/compile.golden.test.ts
@@ -29,6 +29,7 @@ describe('compile() golden path', () => {
           props: { x: 0, y: 0, width: 800, height: 40, fill: '#2a2a2a' },
           zIndex: 1,
           visible: true,
+          sourceRef: { file: 'fixtures/valid.scene.json', line: 10, column: 9 },
         },
         {
           id: 'node:title',
@@ -36,6 +37,7 @@ describe('compile() golden path', () => {
           props: { x: 20, y: 10, content: 'Terminal v0.3', color: '#00ff00', fontSize: 14 },
           zIndex: 2,
           visible: true,
+          sourceRef: { file: 'fixtures/valid.scene.json', line: 18, column: 9 },
         },
       ],
       metadata: { sourceFormat: 'canonical-ast-json' },
@@ -57,6 +59,7 @@ describe('compile() golden path', () => {
     expect(result.ok).toBe(true);
     expect(result.diagnostics.filter((d) => d.severity === 'error')).toHaveLength(0);
     expect(result.artifacts['scene.geordi.json']).toBeDefined();
+    expect(result.artifacts['scene.geordi.map.json']).toBeDefined();
     expect(result.artifacts['types.ts']).toBeDefined();
 
     const ir = parseJsonValue(String(result.artifacts['scene.geordi.json'].content)) as GeordiIr;
@@ -65,6 +68,22 @@ describe('compile() golden path', () => {
     expect(ir.scene.id).toBe('scene:terminal');
     expect(Array.isArray(ir.nodes)).toBe(true);
     expect(ir.nodes.length).toBe(2);
+    expect(ir.nodes.some((node) => 'sourceRef' in node)).toBe(false);
+
+    const sourceMap = parseJsonValue(String(result.artifacts['scene.geordi.map.json'].content)) as JsonObject;
+    expect(sourceMap.version).toBe('geordi-source-map/1');
+    expect(sourceMap.irVersion).toBe('geordi-ir/1');
+    expect(sourceMap.sourceFormat).toBe('canonical-ast-json');
+    expect(sourceMap.nodes).toEqual([
+      {
+        id: 'node:header',
+        source: { column: 9, file: 'fixtures/valid.scene.json', line: 10 },
+      },
+      {
+        id: 'node:title',
+        source: { column: 9, file: 'fixtures/valid.scene.json', line: 18 },
+      },
+    ]);
   });
 
   it('scene.geordi.json.receipt is present and contains irHash', async () => {
@@ -93,11 +112,15 @@ describe('compile() golden path', () => {
     expect(receipt.numericProfile).toBe(GEORDI_NUMERIC_PROFILE);
     expect(receipt.inputHash).toBe(sha256(source));
     expect(typeof receipt.rulesetFingerprint).toBe('string');
+    expect(typeof receipt.sourceMapHash).toBe('string');
+    expect(receipt.sourceMapHashAlg).toBe('sha256');
 
     // irHash must match sha256 of the emitted IR
     const irContent = String(result.artifacts['scene.geordi.json'].content);
+    const sourceMapContent = String(result.artifacts['scene.geordi.map.json'].content);
     expect(receipt.irHash).toBe(sha256(irContent));
     expect(receipt.irHashAlg).toBe('sha256');
+    expect(receipt.sourceMapHash).toBe(sha256(sourceMapContent));
   });
 
   it('inputHash in receipt matches sha256(input.source)', async () => {

--- a/packages/compiler-core/test/formatDiagnostics.test.ts
+++ b/packages/compiler-core/test/formatDiagnostics.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { Diagnostic } from '../src/types';
+import {
+  formatDiagnostic,
+  formatDiagnostics,
+  formatSourceLocation,
+} from '../src/diagnostics';
+
+describe('diagnostic formatter', () => {
+  it('formats source locations with optional spans', () => {
+    expect(formatSourceLocation({ file: 'scene.graphql', line: 2, column: 3 })).toBe(
+      'scene.graphql:2:3',
+    );
+    expect(
+      formatSourceLocation({
+        file: 'scene.graphql',
+        line: 2,
+        column: 3,
+        endLine: 2,
+        endColumn: 12,
+      }),
+    ).toBe('scene.graphql:2:3-2:12');
+  });
+
+  it('formats a single diagnostic with stable details ordering', () => {
+    const diagnostic: Diagnostic = {
+      code: 'GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE',
+      severity: 'error',
+      message: 'Argument x must be number',
+      location: {
+        file: 'scene.graphql',
+        line: 4,
+        column: 41,
+        endLine: 4,
+        endColumn: 47,
+      },
+      hint: 'Use a numeric literal.',
+      details: {
+        expected: 'number',
+        actual: 'string',
+        argument: 'x',
+      },
+    };
+
+    expect(formatDiagnostic(diagnostic)).toBe(
+      [
+        'error GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE scene.graphql:4:41-4:47 Argument x must be number',
+        'hint: Use a numeric literal.',
+        'details: {"actual":"string","argument":"x","expected":"number"}',
+      ].join('\n'),
+    );
+  });
+
+  it('can omit details deterministically', () => {
+    const diagnostic: Diagnostic = {
+      code: 'GEORDI_W_UNUSED_FIELD',
+      severity: 'warning',
+      message: 'Ignoring field',
+      details: { field: 'extra' },
+    };
+
+    expect(formatDiagnostic(diagnostic, { includeDetails: false })).toBe(
+      'warning GEORDI_W_UNUSED_FIELD Ignoring field',
+    );
+  });
+
+  it('formats multiple diagnostics in input order', () => {
+    const diagnostics: readonly Diagnostic[] = [
+      {
+        code: 'GEORDI_E_FIRST',
+        severity: 'error',
+        message: 'First',
+      },
+      {
+        code: 'GEORDI_E_SECOND',
+        severity: 'error',
+        message: 'Second',
+      },
+    ];
+
+    expect(formatDiagnostics(diagnostics)).toBe(
+      ['error GEORDI_E_FIRST First', 'error GEORDI_E_SECOND Second'].join('\n\n'),
+    );
+  });
+});

--- a/packages/compiler-core/test/sourceLocation.test.ts
+++ b/packages/compiler-core/test/sourceLocation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSourceLocation,
+  INLINE_SOURCE_FILE,
+  InvalidSourceLocationError,
+} from '../src/types';
+
+describe('source location model', () => {
+  it('normalizes missing source input to the inline start location', () => {
+    expect(createSourceLocation()).toEqual({
+      file: INLINE_SOURCE_FILE,
+      line: 1,
+      column: 1,
+    });
+  });
+
+  it('keeps exact file, span, and offset data when provided', () => {
+    expect(
+      createSourceLocation({
+        file: 'scene.graphql',
+        line: 3,
+        column: 5,
+        endLine: 3,
+        endColumn: 22,
+        offset: 18,
+        endOffset: 35,
+      }),
+    ).toEqual({
+      file: 'scene.graphql',
+      line: 3,
+      column: 5,
+      endLine: 3,
+      endColumn: 22,
+      offset: 18,
+      endOffset: 35,
+    });
+  });
+
+  it('rejects invalid one-based positions with a custom error', () => {
+    expect(() => createSourceLocation({ line: 0 })).toThrow(InvalidSourceLocationError);
+    expect(() => createSourceLocation({ column: Number.POSITIVE_INFINITY })).toThrow(
+      InvalidSourceLocationError,
+    );
+  });
+
+  it('rejects incomplete or backwards spans with a custom error', () => {
+    expect(() => createSourceLocation({ endLine: 1 })).toThrow(InvalidSourceLocationError);
+    expect(() =>
+      createSourceLocation({ line: 5, column: 10, endLine: 5, endColumn: 9 }),
+    ).toThrow(InvalidSourceLocationError);
+  });
+
+  it('rejects negative or backwards offsets with a custom error', () => {
+    expect(() => createSourceLocation({ offset: -1 })).toThrow(InvalidSourceLocationError);
+    expect(() => createSourceLocation({ offset: 5, endOffset: 4 })).toThrow(
+      InvalidSourceLocationError,
+    );
+  });
+});

--- a/packages/schema-graphql/src/parse/extractScene.ts
+++ b/packages/schema-graphql/src/parse/extractScene.ts
@@ -1,5 +1,9 @@
 import { type DocumentNode, type ObjectTypeDefinitionNode, Kind } from 'graphql';
-import { ParseError, GeordiErrorCode } from '@flyingrobots/geordi-compiler-core';
+import {
+  createSourceLocation,
+  ParseError,
+  GeordiErrorCode,
+} from '@flyingrobots/geordi-compiler-core';
 import type { Diagnostic, SourceRef } from '@flyingrobots/geordi-compiler-core';
 import { validateGeordiDirectiveVersion } from '../directives/geordiDirectives.js';
 import {
@@ -45,7 +49,7 @@ export function extractScene(
       new ParseError(
         GeordiErrorCode.E_SCENE_MISSING,
         'No type with @geordi_scene directive found. Add @geordi_scene(v: "1", width: N, height: N) to exactly one type.',
-        { location: { file: filename ?? '<inline>', line: 1, column: 1 } },
+        { location: createSourceLocation({ file: filename }) },
       ).toDiagnostic(),
     );
     return undefined;

--- a/packages/schema-graphql/src/parse/parseGraphql.ts
+++ b/packages/schema-graphql/src/parse/parseGraphql.ts
@@ -1,5 +1,11 @@
 import { parse, Source, GraphQLError, type DocumentNode } from 'graphql';
-import { ParseError, GeordiErrorCode, normalizeCompilerErrorCause, type ThrownValue } from '@flyingrobots/geordi-compiler-core';
+import {
+  createSourceLocation,
+  ParseError,
+  GeordiErrorCode,
+  normalizeCompilerErrorCause,
+  type ThrownValue,
+} from '@flyingrobots/geordi-compiler-core';
 
 /**
  * Parse a GraphQL SDL string into a DocumentNode.
@@ -12,12 +18,12 @@ export function parseGraphql(sdl: string, filename?: string): DocumentNode {
   } catch (cause) {
     const location =
       cause instanceof GraphQLError && cause.locations?.[0]
-        ? {
+        ? createSourceLocation({
             file: effectiveName,
             line: cause.locations[0].line,
             column: cause.locations[0].column,
-          }
-        : { file: effectiveName, line: 1, column: 1 };
+          })
+        : createSourceLocation({ file: effectiveName });
 
     throw new ParseError(
       GeordiErrorCode.E_INPUT_INVALID_SDL,

--- a/packages/schema-graphql/src/parse/sourceRef.ts
+++ b/packages/schema-graphql/src/parse/sourceRef.ts
@@ -1,4 +1,5 @@
 import { getLocation, type Source } from 'graphql';
+import { createSourceLocation } from '@flyingrobots/geordi-compiler-core';
 import type { SourceRef } from '@flyingrobots/geordi-compiler-core';
 
 /**
@@ -6,16 +7,21 @@ import type { SourceRef } from '@flyingrobots/geordi-compiler-core';
  * Null-safe: if loc is absent, returns file/<inline>, line 1, col 1.
  */
 export function nodeSourceRef(
-  node: { loc?: { start: number; source: Source } },
+  node: { loc?: { start: number; end: number; source: Source } },
   filename?: string,
 ): SourceRef {
   if (node.loc) {
-    const { line, column } = getLocation(node.loc.source, node.loc.start);
-    return {
+    const start = getLocation(node.loc.source, node.loc.start);
+    const end = getLocation(node.loc.source, node.loc.end);
+    return createSourceLocation({
       file: filename ?? node.loc.source.name,
-      line,
-      column,
-    };
+      line: start.line,
+      column: start.column,
+      endLine: end.line,
+      endColumn: end.column,
+      offset: node.loc.start,
+      endOffset: node.loc.end,
+    });
   }
-  return { file: filename ?? '<inline>', line: 1, column: 1 };
+  return createSourceLocation({ file: filename });
 }

--- a/packages/schema-graphql/test/e2e.terminal.test.ts
+++ b/packages/schema-graphql/test/e2e.terminal.test.ts
@@ -49,6 +49,11 @@ function irContent(result: CompileResult): string {
   return String(artifact.content);
 }
 
+function sourceMapContent(result: CompileResult): string {
+  const artifact = result.artifacts['scene.geordi.map.json'];
+  return String(artifact.content);
+}
+
 function parseIr(result: CompileResult): GeordiIr {
   return parseJsonValue(irContent(result)) as GeordiIr;
 }
@@ -122,6 +127,31 @@ describe('e2e: Terminal SDL fixture', () => {
     expect(ir.scene.width).toBe(800);
     expect(ir.scene.height).toBe(600);
     expect(ir.scene.units).toBe('px');
+  });
+
+  it('emits a source map from IR node ids to SDL field locations', async () => {
+    const result = await compile(makeInput(TERMINAL_SDL), DEPS);
+    expect(result.ok).toBe(true);
+
+    const sourceMap = parseJsonValue(sourceMapContent(result)) as {
+      readonly nodes?: readonly {
+        readonly id?: string;
+        readonly source?: {
+          readonly file?: string;
+          readonly line?: number;
+          readonly column?: number;
+        };
+      }[];
+    };
+    const ir = parseIr(result);
+    const titleNode = ir.nodes.find((node) => node.props.content === 'Terminal v0.3');
+    const titleMapping = sourceMap.nodes?.find((node) => node.id === titleNode?.id);
+
+    expect(titleMapping?.source).toMatchObject({
+      file: 'terminal.graphql',
+      line: 5,
+      column: 3,
+    });
   });
 
   it('metadata contains hashAlgorithm', async () => {

--- a/packages/schema-graphql/test/extractNodes.test.ts
+++ b/packages/schema-graphql/test/extractNodes.test.ts
@@ -36,6 +36,28 @@ describe('extractNodes (table-driven)', () => {
     expect(bg.height).toBe(600);
   });
 
+  it('attaches exact field source span to extracted nodes', () => {
+    const diag: Diagnostic[] = [];
+    const { nodes } = parseAndExtract(
+      [
+        'type S @geordi_scene(v: "1", width: 100, height: 100) {',
+        '  title: String @geordi_node(kind: Text, x: 10, y: 20)',
+        '}',
+      ].join('\n'),
+      diag,
+    );
+
+    expect(nodes[0].sourceRef).toMatchObject({
+      file: 'test.graphql',
+      line: 2,
+      column: 3,
+      endLine: 2,
+    });
+    expect(nodes[0].sourceRef.endColumn).toBeGreaterThan(nodes[0].sourceRef.column);
+    expect(nodes[0].sourceRef.offset).toBeGreaterThan(0);
+    expect(nodes[0].sourceRef.endOffset).toBeGreaterThan(nodes[0].sourceRef.offset ?? 0);
+  });
+
   it('extracts all valid node kinds', () => {
     for (const kind of ['Rect', 'Text', 'Image', 'Group', 'Line', 'Ellipse', 'Path']) {
       const diag: Diagnostic[] = [];
@@ -168,6 +190,24 @@ describe('extractNodes (table-driven)', () => {
     ]);
     expect(errors.map((d) => d.message).join('\n')).toContain('x');
     expect(errors.map((d) => d.message).join('\n')).toContain('visible');
+  });
+
+  it('pins invalid directive argument value locations', () => {
+    const diag: Diagnostic[] = [];
+    parseAndExtract(
+      [
+        'type S @geordi_scene(v: "1", width: 100, height: 100) {',
+        '  n: String @geordi_node(kind: Rect, x: "left", visible: "yes")',
+        '}',
+      ].join('\n'),
+      diag,
+    );
+
+    const errors = diag.filter((d) => d.severity === 'error');
+    expect(errors.map((d) => d.location)).toEqual([
+      expect.objectContaining({ file: 'test.graphql', line: 2, column: 41 }),
+      expect.objectContaining({ file: 'test.graphql', line: 2, column: 58 }),
+    ]);
   });
 
   it('non-finite numeric node argument → GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE', () => {

--- a/packages/schema-graphql/test/extractScene.test.ts
+++ b/packages/schema-graphql/test/extractScene.test.ts
@@ -134,6 +134,29 @@ describe('extractScene (table-driven)', () => {
     expect(scene?.sourceRef.column).toBeGreaterThanOrEqual(1);
   });
 
+  it('attaches exact scene type source span', () => {
+    const doc = parseGraphql(
+      [
+        'type Terminal @geordi_scene(v: "1", width: 800, height: 600) {',
+        '  _: String',
+        '}',
+      ].join('\n'),
+      'scene.graphql',
+    );
+    const diag: Diagnostic[] = [];
+    const scene = extractScene(doc, diag, 'scene.graphql');
+
+    expect(scene?.sourceRef).toMatchObject({
+      file: 'scene.graphql',
+      line: 1,
+      column: 1,
+      endLine: 3,
+      offset: 0,
+    });
+    expect(scene?.sourceRef.endColumn).toBeGreaterThan(1);
+    expect(scene?.sourceRef.endOffset).toBeGreaterThan(0);
+  });
+
   it('sourceRef fallback when no filename provided', () => {
     const doc = parse(`
       type Terminal @geordi_scene(v: "1", width: 800, height: 600) { _: String }

--- a/packages/wesley-generator/src/GeordiGeneratorPlugin.ts
+++ b/packages/wesley-generator/src/GeordiGeneratorPlugin.ts
@@ -1,4 +1,9 @@
-import { compile, type CompilerInput, type ParseInputDeps } from '@flyingrobots/geordi-compiler-core';
+import {
+  compile,
+  formatDiagnostic,
+  type CompilerInput,
+  type ParseInputDeps,
+} from '@flyingrobots/geordi-compiler-core';
 import { graphqlToCanonicalAst } from '@flyingrobots/geordi-schema-graphql';
 // import { GeneratorPlugin } from '@wesley/core';
 
@@ -100,8 +105,7 @@ export class GeordiGeneratorPlugin {
     const result = await compile(input, deps);
 
     for (const d of result.diagnostics) {
-      const line = d.location ? `${d.location.file}:${d.location.line}:${d.location.column}` : 'unknown';
-      const msg = `[${d.code}] ${d.message} (${line})`;
+      const msg = formatDiagnostic(d);
       if (d.severity === 'error') context.logger?.error?.(msg);
       else if (d.severity === 'warning') context.logger?.warn?.(msg);
       else context.logger?.info?.(msg);

--- a/packages/wesley-generator/src/GeordiGeneratorPlugin.ts
+++ b/packages/wesley-generator/src/GeordiGeneratorPlugin.ts
@@ -65,6 +65,7 @@ export class GeordiGeneratorPlugin {
     return {
       artifacts: [
         { path: 'scene.geordi.json', reason: 'Geordi IR scene' },
+        { path: 'scene.geordi.map.json', reason: 'Geordi IR source map' },
         { path: 'types.ts', reason: 'TypeScript types for scene artifacts' },
       ],
       metadata: {

--- a/packages/wesley-generator/src/index.test.ts
+++ b/packages/wesley-generator/src/index.test.ts
@@ -55,6 +55,7 @@ describe('wesley-generator public API', () => {
     const plan = plugin.plan({ sdl: MINIMAL_SDL }, context);
     expect(plan.artifacts.map((artifact) => artifact.path)).toEqual([
       'scene.geordi.json',
+      'scene.geordi.map.json',
       'types.ts',
     ]);
     expect(plan.metadata).toEqual({
@@ -66,6 +67,7 @@ describe('wesley-generator public API', () => {
     expect(Object.keys(output).sort()).toEqual([
       'scene.geordi.json',
       'scene.geordi.json.receipt',
+      'scene.geordi.map.json',
       'types.ts',
     ]);
 


### PR DESCRIPTION
## Summary

Adds the first source-map and diagnostic UX tranche on top of the current Geordi IR contract.

- Reconciles repo tracking docs after PR #17 and closes stale issue #7.
- Adds a canonical compiler-core source-location model shared by AST `SourceRef` and diagnostics.
- Preserves exact GraphQL source spans and offsets for scene, node, and directive argument locations.
- Adds a deterministic diagnostic formatter with canonical JSON details and source-span rendering.
- Emits `scene.geordi.map.json` alongside IR JSON, mapping IR node IDs back to source locations.
- Adds `sourceMapHash` / `sourceMapHashAlg` to receipts.
- Adds `pnpm wesley` as a thin shell-out to the installed Wesley CLI.

## Notes

The original five source-map slices are preserved as separate commits. The Wesley script is an additional small commit requested during the work.

## Commits

- `83440ef` - `Reconcile source map backlog tracking`
- `615a7d4` - `Add canonical source location model`
- `7bea723` - `Add Wesley CLI package script`
- `6c89043` - `Propagate GraphQL source spans`
- `5aa5a62` - `Add deterministic diagnostic formatter`
- `dd00bb6` - `Emit Geordi source map artifacts`

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` - 178 package tests passed
- `pnpm test:docs`
- `pnpm test:package-names`
- `pnpm test:repo-sludge`
- `pnpm test:placeholders`
- `pnpm test:exports`
- `git diff --check`

## Follow-up

Next logical PR: define the explicit feature/capability profile beyond the current v0 baseline, then wire IR `requires` validation and runtime support checks.
