### PR TITLE
[codex] Add Geordi capability profile contract

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -65,6 +65,26 @@ Acceptance criteria:
 
 ---
 
+### Define the baseline feature/capability profile
+**Priority**: P0
+**Source**: v0 design laws, cross-runtime compliance contract
+**Status**: Completed. Core owns `GEORDI_CORE_PROFILE` and `GEORDI_BASELINE_FEATURES`,
+`geordi-ir/1` validates `requires`, compiler-core emits the baseline requirements in IR and
+receipts, and runtime-webgl declares and enforces the same requirement set before rendering.
+
+The numeric profile defines number semantics, but it does not say which render features a scene
+requires. `geordi-ir/1` needs a small, explicit feature declaration so runtimes fail loudly instead
+of approximating unsupported nodes, effects, text modes, or future layout features.
+
+Acceptance criteria:
+- `@flyingrobots/geordi-core` owns the baseline feature vocabulary and validates `ir.requires`.
+- Compiler-emitted `scene.geordi.json` includes the baseline `requires` list.
+- Receipts record feature requirements and a deterministic feature-requirement hash.
+- Runtime profiles declare the feature requirements they support.
+- Runtime rendering rejects missing or unsupported feature requirements before drawing.
+
+---
+
 ## Completed Stabilization Work
 
 These P0 items were completed in the 2026-05-22 stabilization work and are retained here as
@@ -97,7 +117,10 @@ historical context.
   drawable props, and compiler output is rendered through the runtime contract in tests.
 - Graphics numeric profile is explicit: core owns `geordi-finite-binary64/1`, canonical JSON
   rejects non-finite numbers and canonicalizes `-0`, compiler IR and receipts declare the profile,
-  and runtime-webgl rejects unsupported profile requirements before rendering.
+  and runtime-webgl rejects unsupported numeric profiles before rendering.
+- Baseline feature profile is explicit: core owns `GEORDI_BASELINE_FEATURES`, compiler IR and
+  receipts declare `requires`, receipts include `featureRequirementsHash`, and runtime-webgl
+  rejects missing or unsupported feature requirements before rendering.
 
 ---
 

--- a/BEARING.md
+++ b/BEARING.md
@@ -1,8 +1,8 @@
 # Geordi Bearing
 
 **Date**: 2026-05-23
-**Branch baseline**: `main` at `2dcf510`
-**Current head when written**: `2dcf510`
+**Branch baseline**: `main` at `fce5978`
+**Current branch when written**: `p0/capability-profile-contract`
 
 This file is the short-term operating map. Product rationale remains in
 [`docs/V0_DESIGN_LAWS.md`](./docs/V0_DESIGN_LAWS.md); detailed work items remain in
@@ -41,7 +41,11 @@ Completed:
 - `@flyingrobots/geordi-core` owns the canonical JSON port, including parse/stringify/normalize
   behavior and custom JSON error types.
 - `geordi-ir/1` declares `numericProfile: "geordi-finite-binary64/1"`; compiler receipts include
-  that profile, and runtime-webgl rejects unsupported profile requirements before rendering.
+  that profile, and runtime-webgl rejects unsupported numeric profiles before rendering.
+- `@flyingrobots/geordi-core` owns the baseline feature profile
+  (`GEORDI_BASELINE_FEATURES`, rooted at `geordi/core/1`), `geordi-ir/1` declares `requires`,
+  compiler output and receipts record those requirements, and runtime-webgl rejects missing or
+  unsupported feature requirements before rendering.
 - Public TypeScript API names are de-versioned for the current IR surface: use `GeordiIr`,
   `validateGeordiIr()`, `isGeordiIr()`, and compiler target `geordi-ir`; payload/profile
   identities remain explicit through values such as `irVersion: "geordi-ir/1"`.
@@ -61,15 +65,19 @@ Still true:
 
 ## Immediate Moves
 
-1. Define the next explicit feature/capability profile beyond the v0 baseline.
-2. Keep source-map and diagnostic formatter behavior wired into future CLI/Wesley entrypoints.
-3. Keep dependency hygiene clean; there are no open PRs at the time this bearing was refreshed.
+1. Specify deterministic operation-order rules for future vector, matrix, transform, and animation
+   math before adding those features to any profile.
+2. Define the next strict text/font profile beyond `text.raw-runtime-shaping` so pixel-identical
+   text can become a real compliance claim.
+3. Keep source-map, diagnostic formatter, and receipt behavior wired into future CLI/Wesley
+   entrypoints.
 
 ## Recommended P0 Order
 
-1. Define the next feature/capability profile beyond the v0 baseline.
+1. Define the next strict text/font feature profile beyond the current v0 baseline.
 2. Decide whether Wesley modernization should target `wesley-cli`/`wesley-core` 0.0.5 through a
    CLI boundary, Rust workspace boundary, or future npm/WASM boundary.
+3. Keep dependency hygiene clean; there are no open PRs at the time this bearing was refreshed.
 
 ## Dependency Work
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@
 - **`@flyingrobots/geordi-runtime-webgl`**: Add `GEORDI_WEBGL_RUNTIME_PROFILE` and fail loudly
   with `GeordiRuntimeUnsupportedProfileError` when IR requests an unsupported IR version or
   numeric profile.
+- **`@flyingrobots/geordi-core`**: Add the baseline feature profile
+  (`GEORDI_CORE_PROFILE`, `GEORDI_BASELINE_FEATURES`) and require `geordi-ir/1` artifacts to
+  declare supported `requires` values.
+- **`@flyingrobots/geordi-compiler-core`**: Emit baseline feature requirements in
+  `scene.geordi.json`, record them in receipts, and add a deterministic
+  `featureRequirementsHash`.
+- **`@flyingrobots/geordi-runtime-webgl`**: Add baseline feature requirements to
+  `GEORDI_WEBGL_RUNTIME_PROFILE` and fail loudly when IR omits `requires` or asks for unsupported
+  features.
 - **Public API**: De-version the current IR TypeScript surface (`GeordiIr`,
   `validateGeordiIr()`, `isGeordiIr()`) and compiler target (`geordi-ir`) while preserving
   `irVersion: "geordi-ir/1"` as the serialized contract identity.
@@ -77,6 +86,9 @@
   spelling, and no hidden fixed-point scaling.
 - **`@flyingrobots/geordi-runtime-webgl`**: add runtime profile export and unsupported profile
   rejection coverage.
+- **Capability profile**: add core validation coverage for baseline feature requirements,
+  compiler golden coverage for emitted requirements and receipt hashes, runtime rejection coverage
+  for unsupported features, and package export smoke coverage for public capability symbols.
 - **`@flyingrobots/geordi-compiler-core`**: add source-location model, diagnostic formatter, and
   source-map artifact coverage.
 - **`@flyingrobots/geordi-schema-graphql`**: add exact GraphQL source-span tests and an e2e source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,8 @@
   rejection coverage.
 - **Capability profile**: add core validation coverage for baseline feature requirements,
   compiler golden coverage for emitted requirements and receipt hashes, runtime rejection coverage
-  for unsupported features, and package export smoke coverage for public capability symbols.
+  for missing, malformed, and unsupported feature requirements, and package export smoke coverage
+  for public capability symbols.
 - **`@flyingrobots/geordi-compiler-core`**: add source-location model, diagnostic formatter, and
   source-map artifact coverage.
 - **`@flyingrobots/geordi-schema-graphql`**: add exact GraphQL source-span tests and an e2e source

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -121,6 +121,7 @@ See [`docs/ERROR_CODES.md`](./ERROR_CODES.md) for complete taxonomy.
 - **IR version**: `irVersion: "geordi-ir/1"` (output format)
 - **Source map version**: `version: "geordi-source-map/1"` (IR node ID to source location map)
 - **Numeric profile**: `numericProfile: "geordi-finite-binary64/1"` (finite binary64 graphics numbers)
+- **Feature profile**: `requires: ["geordi/core/1", ...]` (explicit render capabilities)
 - **Directive version**: `v: "1"` (GraphQL directives)
 
 All versions are explicit and validated. Unknown versions → hard error.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -103,9 +103,9 @@ Latest package test counts for the capability-profile branch:
 | `@flyingrobots/geordi-compiler-core` | 82 | Green |
 | `@flyingrobots/geordi-schema-graphql` | 55 | Green |
 | `@flyingrobots/geordi-core` | 30 | Green |
-| `@flyingrobots/geordi-runtime-webgl` | 13 | Green |
+| `@flyingrobots/geordi-runtime-webgl` | 15 | Green |
 | `@flyingrobots/geordi-wesley-generator` | 3 | Green |
-| **Total package tests** | **183** | Green |
+| **Total package tests** | **185** | Green |
 
 Additional gates:
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-05-23
 **Version**: 0.1.0-dev
-**Milestone**: Source-map and diagnostic UX work starting from `main` at `2dcf510`
+**Milestone**: Capability profile contract work starting from `main` at `fce5978`
 
 See [`../BEARING.md`](../BEARING.md) for the current operating map.
 
@@ -23,7 +23,8 @@ Pure, framework-agnostic compilation engine.
 - GraphQL SDL and canonical JSON input paths.
 - Uses the core-owned deterministic JSON port for canonical parse/stringify boundaries.
 - Deterministic IR, receipt, source-map, and TypeScript type emission.
-- IR and receipt emission declare the v0 numeric profile.
+- IR and receipt emission declare the v0 numeric profile, baseline feature requirements, and
+  feature-requirement hash.
 - Current public IR API names are `GeordiIr`, `validateGeordiIr()`, and `isGeordiIr()`; versioning
   remains in serialized contract values such as `irVersion: "geordi-ir/1"`.
 - Canonical source-location model shared by AST source refs and diagnostics.
@@ -59,6 +60,8 @@ Core domain package.
 - Canonical JSON port with deterministic parse/stringify/normalize behavior and custom JSON
   errors.
 - v0 numeric profile constant `geordi-finite-binary64/1` and graphics-number helpers.
+- Baseline feature profile constants rooted at `geordi/core/1`, plus validation for
+  `geordi-ir/1` `requires`.
 - Current `GeordiIr` structural types and validation for the `geordi-ir/1` payload contract.
 - Draw-ready runtime scene aliases named `PreparedGeordiScene` and `PreparedGeordiNode`.
 - Compatibility aliases for the older scene names remain during the v0.1 migration.
@@ -72,8 +75,9 @@ Canvas-backed WebGL-runtime scaffold.
 - `renderGeordiToCanvas()` is the primary public `geordi-ir/1` rendering API.
 - `renderPreparedSceneToCanvas()` renders draw-ready runtime scenes explicitly.
 - Runtime-bound IR validation and fail-loud prop lowering use custom runtime error types.
-- Runtime capability profile declares supported IR version, numeric profile, node kinds, and visual
-  features.
+- Runtime capability profile declares supported IR version, numeric profile, feature requirements,
+  node kinds, and visual features.
+- Runtime profile checks reject missing or unsupported feature requirements before drawing.
 - Compiler-emitted IR is rendered through the runtime contract in an integration test.
 
 ## Infrastructure
@@ -92,16 +96,16 @@ Canvas-backed WebGL-runtime scaffold.
 
 ## Test Status
 
-Latest full local gate during the core IR runtime-contract work:
+Latest package test counts for the capability-profile branch:
 
 | Package | Tests | Status |
 | --- | ---: | --- |
 | `@flyingrobots/geordi-compiler-core` | 82 | Green |
 | `@flyingrobots/geordi-schema-graphql` | 55 | Green |
-| `@flyingrobots/geordi-core` | 26 | Green |
-| `@flyingrobots/geordi-runtime-webgl` | 12 | Green |
+| `@flyingrobots/geordi-core` | 30 | Green |
+| `@flyingrobots/geordi-runtime-webgl` | 13 | Green |
 | `@flyingrobots/geordi-wesley-generator` | 3 | Green |
-| **Total package tests** | **178** | Green |
+| **Total package tests** | **183** | Green |
 
 Additional gates:
 
@@ -117,9 +121,11 @@ Additional gates:
 
 Immediate:
 
-1. Define the next feature/capability profile beyond the v0 baseline.
-2. Keep source-map and diagnostic formatter behavior wired into future CLI/Wesley entrypoints.
-3. Keep dependency hygiene clean; there are no open PRs at this refresh point.
+1. Define the next strict text/font profile beyond `text.raw-runtime-shaping`.
+2. Specify deterministic operation-order rules for future vector, matrix, transform, and animation
+   math.
+3. Keep source-map, diagnostic formatter, and receipt behavior wired into future CLI/Wesley
+   entrypoints.
 
 Short term:
 

--- a/docs/V0_DESIGN_LAWS.md
+++ b/docs/V0_DESIGN_LAWS.md
@@ -14,7 +14,7 @@ It also defines the v0 design laws that keep Geordi from becoming a generic scen
 
 `geordi-ir/1` is the public renderer contract.
 
-`@flyingrobots/geordi-core` owns the versioned IR types, validation, canonical JSON rules, numeric profile, and compatibility constants. `@flyingrobots/geordi-compiler-core` emits `geordi-ir/1`. Renderers such as `@flyingrobots/geordi-runtime-webgl` accept validated `geordi-ir/1` directly and declare the runtime profile they support.
+`@flyingrobots/geordi-core` owns the versioned IR types, validation, canonical JSON rules, numeric profile, baseline feature profile, and compatibility constants. `@flyingrobots/geordi-compiler-core` emits `geordi-ir/1`. Renderers such as `@flyingrobots/geordi-runtime-webgl` accept validated `geordi-ir/1` directly and declare the runtime profile they support.
 
 A renderer may lower IR into an internal draw-ready cache, GPU command list, packed binary, atlas plan, or scene acceleration structure. That lowering is an implementation detail. It must not become a second public scene format unless it has its own version, validator, and explicit reason to exist.
 
@@ -67,7 +67,7 @@ Recommended top-level direction:
 interface GeordiIr {
   irVersion: 'geordi-ir/1';
   numericProfile: 'geordi-finite-binary64/1';
-  requires: string[];
+  requires: readonly GeordiFeatureRequirement[];
   scene: SceneFrame;
   assets?: AssetManifest;
   nodes: RenderNode[];
@@ -338,7 +338,7 @@ Every IR declares what it requires. Every runtime declares what it supports.
 
 ### Baseline Profile
 
-Recommended baseline profile:
+Current implemented baseline profile:
 
 ```text
 geordi/core/1
@@ -346,17 +346,23 @@ geordi/core/1
 
 Baseline features:
 
+- `geordi/core/1`
+- `layout.resolved`
+- `shape.group`
+- `shape.image`
 - `shape.rect`
-- `shape.roundRect`
+- `shape.text`
 - `paint.solid`
 - `stroke.solid`
-- `clip.rect`
-- `composite.sourceOver`
-- `alpha.premultiplied`
-- `text.glyphRuns`
-- `image.rgba8`
-- `layout.resolved`
-- `hit.geometry`
+- `paint.opacity`
+- `shape.cornerRadius`
+- `text.fill`
+- `text.raw-runtime-shaping`
+
+This baseline is intentionally honest about the current implementation. It allows raw runtime text
+shaping, so it is deterministic only under the numeric and JSON contracts, not yet under a strict
+pixel-identical font law. A future strict text profile should replace or extend
+`text.raw-runtime-shaping` with glyph-run and font-pack requirements.
 
 Optional profiles can extend this, for example:
 
@@ -458,6 +464,17 @@ compiler receipts include the profile, runtime-webgl declares and checks its sup
 and the core JSON port rejects non-finite numbers, canonicalizes `-0`, and does not round or
 fixed-point scale ordinary finite values.
 
+### P0: Define the baseline feature/capability profile
+
+Every IR must declare its required rendering capabilities, and every runtime must reject unsupported
+requirements before drawing.
+
+**Status**: Completed. `@flyingrobots/geordi-core` owns `GEORDI_CORE_PROFILE` and
+`GEORDI_BASELINE_FEATURES`; `geordi-ir/1` validates `requires`; `compiler-core` emits the baseline
+requirements in `scene.geordi.json` and records them plus `featureRequirementsHash` in receipts;
+`runtime-webgl` declares the same feature requirements in `GEORDI_WEBGL_RUNTIME_PROFILE` and
+rejects missing or unsupported requirements.
+
 ### P0: Validate GraphQL directive argument types at runtime
 
 Replace unsafe directive argument casts with typed extractors that emit source-located `GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE` diagnostics.
@@ -504,15 +521,14 @@ These should be answered before locking the v0 IR schema:
 - Should v0 IR use `props.x/y/width/height` temporarily, or should it introduce an explicit `box` field before more runtimes exist?
 - Should `zIndex` remain in emitted IR as debug metadata, or be removed after draw order is resolved?
 - Should layout intent appear in renderable IR, or should renderable IR always contain resolved boxes and optional layout traces?
-- What exact compositor profile should `geordi/core/1` require for WebGL and future native backends?
+- What exact compositor profile should the next strict render-compliance profile require for WebGL
+  and future native backends?
 
 ## Recommended Next Step
 
 The first stabilization pass is merged. Continue in this order:
 
-1. Preserve typed diagnostics across adapter/compiler boundaries.
-2. Validate GraphQL directive argument types at runtime.
-3. Lower or explicitly reject every known Geordi directive.
-4. Expand package behavior tests beyond public entrypoint smoke.
-5. Add source maps and diagnostic UX improvements.
-6. Define the next feature/capability profile beyond the v0 baseline.
+1. Define the next strict text/font profile beyond `text.raw-runtime-shaping`.
+2. Specify deterministic operation-order rules for vector, matrix, transform, and animation math.
+3. Keep source-map, diagnostic formatter, and receipt behavior wired into future CLI/Wesley
+   entrypoints.

--- a/packages/compiler-core/src/compile/emitIr.ts
+++ b/packages/compiler-core/src/compile/emitIr.ts
@@ -90,11 +90,15 @@ export function emitReceiptArtifact(
   const inputHash = hashString(input.source);
   const irHash = hashString(irContent);
   const sourceMapHash = hashString(sourceMapContent);
+  const featureRequirementsHash = hashString(FEATURE_REQUIREMENTS.join('\n'));
   const rulesetFingerprint = hashString([...ruleIds].sort().join('\n'));
 
   const content = stringifyCanonicalJson(
     {
       comparatorVersion: COMPARATOR_VERSION,
+      featureRequirements: [...FEATURE_REQUIREMENTS],
+      featureRequirementsHash,
+      featureRequirementsHashAlg: IR_HASH_ALG,
       inputHash,
       irHash,
       irHashAlg: IR_HASH_ALG,

--- a/packages/compiler-core/src/compile/emitIr.ts
+++ b/packages/compiler-core/src/compile/emitIr.ts
@@ -2,6 +2,7 @@ import type { CanonicalSceneAst } from '../types/ast.js';
 import type { CompilerInput } from '../types/compiler.js';
 import type { Artifact } from '../types/artifacts.js';
 import {
+  GEORDI_BASELINE_FEATURES,
   GEORDI_IR_ARTIFACT_KEY,
   GEORDI_IR_HASH_ALGORITHM,
   GEORDI_IR_RECEIPT_KEY,
@@ -17,6 +18,7 @@ export const IR_VERSION = GEORDI_IR_VERSION;
 export const IR_ARTIFACT_KEY = GEORDI_IR_ARTIFACT_KEY;
 export const IR_RECEIPT_KEY = GEORDI_IR_RECEIPT_KEY;
 export const NUMERIC_PROFILE = GEORDI_NUMERIC_PROFILE;
+export const FEATURE_REQUIREMENTS = GEORDI_BASELINE_FEATURES;
 export const SOURCE_MAP_ARTIFACT_KEY = 'scene.geordi.map.json' as const;
 export const SOURCE_MAP_VERSION = 'geordi-source-map/1' as const;
 
@@ -34,6 +36,7 @@ export function emitGeordiIrArtifact(ast: CanonicalSceneAst): Artifact {
     {
       irVersion: IR_VERSION,
       numericProfile: NUMERIC_PROFILE,
+      requires: [...FEATURE_REQUIREMENTS],
       scene: ast.scene,
       nodes: sorted,
       bindings: ast.bindings ?? [],

--- a/packages/compiler-core/src/types/ir.ts
+++ b/packages/compiler-core/src/types/ir.ts
@@ -5,5 +5,6 @@ export type {
   GeordiIrKeyframe,
   GeordiIrAnimation,
   GeordiIr,
+  GeordiFeatureRequirement,
   GeordiNumericProfile,
 } from '@flyingrobots/geordi-core';

--- a/packages/compiler-core/test/compile.golden.test.ts
+++ b/packages/compiler-core/test/compile.golden.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
-import { GEORDI_NUMERIC_PROFILE } from '@flyingrobots/geordi-core';
+import { GEORDI_BASELINE_FEATURES, GEORDI_NUMERIC_PROFILE } from '@flyingrobots/geordi-core';
 import { compile } from '../src/compile/compile';
 import { GeordiErrorCode } from '../src/errors';
 import { parseJsonValue, stringifyCanonicalJson } from '../src/ports/json';
@@ -65,6 +65,7 @@ describe('compile() golden path', () => {
     const ir = parseJsonValue(String(result.artifacts['scene.geordi.json'].content)) as GeordiIr;
     expect(ir.irVersion).toBe('geordi-ir/1');
     expect(ir.numericProfile).toBe(GEORDI_NUMERIC_PROFILE);
+    expect(ir.requires).toEqual(GEORDI_BASELINE_FEATURES);
     expect(ir.scene.id).toBe('scene:terminal');
     expect(Array.isArray(ir.nodes)).toBe(true);
     expect(ir.nodes.length).toBe(2);

--- a/packages/compiler-core/test/compile.golden.test.ts
+++ b/packages/compiler-core/test/compile.golden.test.ts
@@ -109,6 +109,11 @@ describe('compile() golden path', () => {
 
     const receipt = parseJsonValue(String(result.artifacts['scene.geordi.json.receipt'].content)) as JsonObject;
     expect(receipt.comparatorVersion).toBe('1');
+    expect(receipt.featureRequirements).toEqual(GEORDI_BASELINE_FEATURES);
+    expect(receipt.featureRequirementsHash).toBe(
+      sha256(GEORDI_BASELINE_FEATURES.join('\n')),
+    );
+    expect(receipt.featureRequirementsHashAlg).toBe('sha256');
     expect(receipt.irVersion).toBe('geordi-ir/1');
     expect(receipt.numericProfile).toBe(GEORDI_NUMERIC_PROFILE);
     expect(receipt.inputHash).toBe(sha256(source));

--- a/packages/compiler-core/test/coreIrContract.test.ts
+++ b/packages/compiler-core/test/coreIrContract.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { GEORDI_NUMERIC_PROFILE, validateGeordiIr } from '@flyingrobots/geordi-core';
+import {
+  GEORDI_BASELINE_FEATURES,
+  GEORDI_NUMERIC_PROFILE,
+  validateGeordiIr,
+} from '@flyingrobots/geordi-core';
 import type { GeordiIr } from '@flyingrobots/geordi-core';
 import { compile } from '../src/compile/compile';
 import { parseJsonValue, stringifyCanonicalJson } from '../src/ports/json';
@@ -52,5 +56,6 @@ describe('compiler-core to geordi-core IR contract', () => {
     const ir = parseJsonValue(String(artifact.content));
     expect(validateGeordiIr(ir)).toEqual({ ok: true, issues: [] });
     expect((ir as GeordiIr).numericProfile).toBe(GEORDI_NUMERIC_PROFILE);
+    expect((ir as GeordiIr).requires).toEqual(GEORDI_BASELINE_FEATURES);
   });
 });

--- a/packages/core/src/domain/models/GeordiFeatureProfile.test.ts
+++ b/packages/core/src/domain/models/GeordiFeatureProfile.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GEORDI_BASELINE_FEATURES,
+  GEORDI_CORE_PROFILE,
+  isGeordiFeatureRequirement,
+} from './GeordiFeatureProfile';
+
+describe('Geordi feature profile', () => {
+  it('pins the baseline core profile identifier', () => {
+    expect(GEORDI_CORE_PROFILE).toBe('geordi/core/1');
+  });
+
+  it('declares a deterministic baseline feature list', () => {
+    expect(GEORDI_BASELINE_FEATURES).toEqual([
+      'geordi/core/1',
+      'layout.resolved',
+      'shape.group',
+      'shape.image',
+      'shape.rect',
+      'shape.text',
+      'paint.solid',
+      'stroke.solid',
+      'paint.opacity',
+      'shape.cornerRadius',
+      'text.fill',
+      'text.raw-runtime-shaping',
+    ]);
+  });
+
+  it('classifies supported feature requirements', () => {
+    expect(isGeordiFeatureRequirement('shape.rect')).toBe(true);
+    expect(isGeordiFeatureRequirement('effect.blur/1')).toBe(false);
+  });
+});

--- a/packages/core/src/domain/models/GeordiFeatureProfile.ts
+++ b/packages/core/src/domain/models/GeordiFeatureProfile.ts
@@ -1,0 +1,26 @@
+export const GEORDI_CORE_PROFILE = 'geordi/core/1' as const;
+
+export const GEORDI_BASELINE_FEATURES = [
+  GEORDI_CORE_PROFILE,
+  'layout.resolved',
+  'shape.group',
+  'shape.image',
+  'shape.rect',
+  'shape.text',
+  'paint.solid',
+  'stroke.solid',
+  'paint.opacity',
+  'shape.cornerRadius',
+  'text.fill',
+  'text.raw-runtime-shaping',
+] as const;
+
+export type GeordiFeatureRequirement = (typeof GEORDI_BASELINE_FEATURES)[number];
+
+const GEORDI_BASELINE_FEATURE_SET = new Set<string>(GEORDI_BASELINE_FEATURES);
+
+export function isGeordiFeatureRequirement(
+  value: string,
+): value is GeordiFeatureRequirement {
+  return GEORDI_BASELINE_FEATURE_SET.has(value);
+}

--- a/packages/core/src/domain/models/GeordiIr.test.ts
+++ b/packages/core/src/domain/models/GeordiIr.test.ts
@@ -4,11 +4,13 @@ import {
   isGeordiIr,
   validateGeordiIr,
 } from './GeordiIr';
+import { GEORDI_BASELINE_FEATURES } from './GeordiFeatureProfile';
 import { GEORDI_NUMERIC_PROFILE } from './GeordiNumericProfile';
 
 const VALID_IR = {
   irVersion: GEORDI_IR_VERSION,
   numericProfile: GEORDI_NUMERIC_PROFILE,
+  requires: GEORDI_BASELINE_FEATURES,
   scene: {
     id: 'scene:test',
     width: 320,
@@ -65,6 +67,32 @@ describe('Geordi IR contract', () => {
     expect(unsupportedResult.ok).toBe(false);
     expect(missingResult.issues.map((issue) => issue.path)).toContain('$.numericProfile');
     expect(unsupportedResult.issues.map((issue) => issue.path)).toContain('$.numericProfile');
+  });
+
+  it('rejects missing or malformed feature requirements', () => {
+    const missingRequirements = { ...VALID_IR };
+    Reflect.deleteProperty(missingRequirements, 'requires');
+
+    const missingResult = validateGeordiIr(missingRequirements);
+    const malformedResult = validateGeordiIr({
+      ...VALID_IR,
+      requires: ['geordi/core/1', 'effect.blur/1', 1, 'shape.rect', 'shape.rect'],
+    });
+    const missingCoreProfileResult = validateGeordiIr({
+      ...VALID_IR,
+      requires: ['shape.rect'],
+    });
+
+    expect(missingResult.ok).toBe(false);
+    expect(malformedResult.ok).toBe(false);
+    expect(missingCoreProfileResult.ok).toBe(false);
+    expect(missingResult.issues.map((issue) => issue.path)).toContain('$.requires');
+    expect(malformedResult.issues.map((issue) => issue.path)).toEqual([
+      '$.requires[1]',
+      '$.requires[2]',
+      '$.requires[4]',
+    ]);
+    expect(missingCoreProfileResult.issues.map((issue) => issue.path)).toContain('$.requires');
   });
 
   it('rejects non-finite scene dimensions and node z-index', () => {

--- a/packages/core/src/domain/models/GeordiIr.ts
+++ b/packages/core/src/domain/models/GeordiIr.ts
@@ -1,5 +1,10 @@
 import type { JsonObject, JsonValue } from './GeordiScene.js';
 import {
+  GEORDI_CORE_PROFILE,
+  isGeordiFeatureRequirement,
+  type GeordiFeatureRequirement,
+} from './GeordiFeatureProfile.js';
+import {
   GEORDI_NUMERIC_PROFILE,
   isFiniteGraphicsNumber,
   type GeordiNumericProfile,
@@ -54,6 +59,7 @@ export interface GeordiIrAnimation extends JsonObject {
 export interface GeordiIr extends JsonObject {
   readonly irVersion: typeof GEORDI_IR_VERSION;
   readonly numericProfile: GeordiNumericProfile;
+  readonly requires: readonly GeordiFeatureRequirement[];
   readonly scene: GeordiIrScene;
   readonly nodes: readonly GeordiIrNode[];
   readonly bindings?: readonly GeordiIrBinding[];
@@ -95,6 +101,7 @@ export function validateGeordiIr(value: JsonValue | undefined): GeordiIrValidati
   }
 
   validateScene(property(value, 'scene'), issues);
+  validateRequires(property(value, 'requires'), issues);
   validateNodes(property(value, 'nodes'), issues);
   validateBindings(property(value, 'bindings'), issues);
   validateAnimations(property(value, 'animations'), issues);
@@ -113,6 +120,43 @@ function validateScene(value: JsonValue | undefined, issues: GeordiIrValidationI
   requirePositiveFiniteNumber(value, 'height', '$.scene.height', issues);
   optionalLiteral(value, 'units', 'px', '$.scene.units', issues);
   optionalString(value, 'background', '$.scene.background', issues);
+}
+
+function validateRequires(value: JsonValue | undefined, issues: GeordiIrValidationIssue[]): void {
+  if (!isJsonArray(value)) {
+    pushIssue(issues, '$.requires', 'IR requires must be an array');
+    return;
+  }
+
+  const seen = new Set<string>();
+  let hasCoreProfile = false;
+
+  for (let i = 0; i < value.length; i++) {
+    const requirement = value[i];
+    const path = `$.requires[${i}]`;
+
+    if (typeof requirement !== 'string') {
+      pushIssue(issues, path, 'IR requirement must be a string');
+      continue;
+    }
+
+    if (!isGeordiFeatureRequirement(requirement)) {
+      pushIssue(issues, path, 'IR requirement is not supported by this IR version');
+    }
+
+    if (seen.has(requirement)) {
+      pushIssue(issues, path, 'IR requirement must not be duplicated');
+    }
+    seen.add(requirement);
+
+    if (requirement === GEORDI_CORE_PROFILE) {
+      hasCoreProfile = true;
+    }
+  }
+
+  if (!hasCoreProfile) {
+    pushIssue(issues, '$.requires', `IR requirements must include "${GEORDI_CORE_PROFILE}"`);
+  }
 }
 
 function validateNodes(value: JsonValue | undefined, issues: GeordiIrValidationIssue[]): void {

--- a/packages/core/src/domain/models/index.ts
+++ b/packages/core/src/domain/models/index.ts
@@ -53,6 +53,14 @@ export type {
 export { isPreparedGeordiScene, isGeordiScene } from './GeordiScene.js';
 
 export {
+  GEORDI_BASELINE_FEATURES,
+  GEORDI_CORE_PROFILE,
+  isGeordiFeatureRequirement,
+} from './GeordiFeatureProfile.js';
+
+export type { GeordiFeatureRequirement } from './GeordiFeatureProfile.js';
+
+export {
   GEORDI_IR_VERSION,
   GEORDI_IR_ARTIFACT_KEY,
   GEORDI_IR_RECEIPT_KEY,

--- a/packages/runtime-webgl/src/index.test.ts
+++ b/packages/runtime-webgl/src/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  GEORDI_BASELINE_FEATURES,
   GEORDI_NUMERIC_PROFILE,
   isGeordiIr,
   type GeordiIr,
@@ -187,6 +188,7 @@ function makeIr(): GeordiIr {
   return {
     irVersion: 'geordi-ir/1',
     numericProfile: GEORDI_NUMERIC_PROFILE,
+    requires: GEORDI_BASELINE_FEATURES,
     scene: {
       id: 'scene:runtime-ir',
       width: 100,
@@ -237,6 +239,7 @@ describe('runtime-webgl public API', () => {
     expect(GEORDI_WEBGL_RUNTIME_PROFILE).toEqual({
       irVersion: 'geordi-ir/1',
       numericProfile: GEORDI_NUMERIC_PROFILE,
+      featureRequirements: GEORDI_BASELINE_FEATURES,
       nodeKinds: ['Rect', 'Text', 'Group', 'Image'],
       visualFeatures: ['solid-fill', 'solid-stroke', 'opacity', 'corner-radius', 'text-fill'],
     });
@@ -316,6 +319,17 @@ describe('runtime-webgl public API', () => {
     } as object as GeordiIr;
 
     expect(() => renderGeordiToCanvas(unsupportedProfileIr)).toThrow(
+      GeordiRuntimeUnsupportedProfileError,
+    );
+  });
+
+  it('throws a custom error for unsupported feature requirements', () => {
+    const unsupportedFeatureIr = {
+      ...makeIr(),
+      requires: [...GEORDI_BASELINE_FEATURES, 'effect.blur/1'],
+    } as object as GeordiIr;
+
+    expect(() => renderGeordiToCanvas(unsupportedFeatureIr)).toThrow(
       GeordiRuntimeUnsupportedProfileError,
     );
   });

--- a/packages/runtime-webgl/src/index.test.ts
+++ b/packages/runtime-webgl/src/index.test.ts
@@ -334,6 +334,26 @@ describe('runtime-webgl public API', () => {
     );
   });
 
+  it('throws a custom error when feature requirements are missing', () => {
+    const missingFeatureIr = { ...makeIr() };
+    Reflect.deleteProperty(missingFeatureIr, 'requires');
+
+    expect(() => renderGeordiToCanvas(missingFeatureIr)).toThrow(
+      GeordiRuntimeUnsupportedProfileError,
+    );
+  });
+
+  it('throws a custom error when feature requirements are malformed', () => {
+    const malformedFeatureIr = {
+      ...makeIr(),
+      requires: ['geordi/core/1', 7],
+    } as object as GeordiIr;
+
+    expect(() => renderGeordiToCanvas(malformedFeatureIr)).toThrow(
+      GeordiRuntimeUnsupportedProfileError,
+    );
+  });
+
   it('throws a custom error for unsupported IR versions', () => {
     const unsupportedVersionIr = {
       ...makeIr(),

--- a/packages/runtime-webgl/src/profile.ts
+++ b/packages/runtime-webgl/src/profile.ts
@@ -1,6 +1,8 @@
 import {
+  GEORDI_BASELINE_FEATURES,
   GEORDI_IR_VERSION,
   GEORDI_NUMERIC_PROFILE,
+  type GeordiFeatureRequirement,
   type GeordiNumericProfile,
 } from '@flyingrobots/geordi-core';
 
@@ -16,6 +18,7 @@ export type GeordiRuntimeVisualFeature =
 export interface GeordiRuntimeProfile {
   readonly irVersion: typeof GEORDI_IR_VERSION;
   readonly numericProfile: GeordiNumericProfile;
+  readonly featureRequirements: readonly GeordiFeatureRequirement[];
   readonly nodeKinds: readonly GeordiRuntimeNodeKind[];
   readonly visualFeatures: readonly GeordiRuntimeVisualFeature[];
 }
@@ -23,6 +26,7 @@ export interface GeordiRuntimeProfile {
 export const GEORDI_WEBGL_RUNTIME_PROFILE: GeordiRuntimeProfile = {
   irVersion: GEORDI_IR_VERSION,
   numericProfile: GEORDI_NUMERIC_PROFILE,
+  featureRequirements: GEORDI_BASELINE_FEATURES,
   nodeKinds: ['Rect', 'Text', 'Group', 'Image'],
   visualFeatures: ['solid-fill', 'solid-stroke', 'opacity', 'corner-radius', 'text-fill'],
 };
@@ -42,6 +46,7 @@ export class GeordiRuntimeUnsupportedProfileError extends Error {
 interface RuntimeProfileRequirement {
   readonly irVersion: string;
   readonly numericProfile?: string;
+  readonly requires?: readonly string[];
 }
 
 export function assertSupportedRuntimeProfile(
@@ -60,5 +65,29 @@ export function assertSupportedRuntimeProfile(
       `numericProfile=${String(ir.numericProfile)}`,
       `numericProfile=${profile.numericProfile}`,
     );
+  }
+
+  if (!Array.isArray(ir.requires)) {
+    throw new GeordiRuntimeUnsupportedProfileError(
+      'requires=<missing>',
+      `requires=${profile.featureRequirements.join(',')}`,
+    );
+  }
+
+  const supportedFeatureRequirements = new Set<string>(profile.featureRequirements);
+  for (const [index, requirement] of ir.requires.entries()) {
+    if (typeof requirement !== 'string') {
+      throw new GeordiRuntimeUnsupportedProfileError(
+        `requires[${index}]=${String(requirement)}`,
+        `requires=${profile.featureRequirements.join(',')}`,
+      );
+    }
+
+    if (!supportedFeatureRequirements.has(requirement)) {
+      throw new GeordiRuntimeUnsupportedProfileError(
+        `requires=${requirement}`,
+        `requires=${profile.featureRequirements.join(',')}`,
+      );
+    }
   }
 }

--- a/scripts/smoke-package-exports.mjs
+++ b/scripts/smoke-package-exports.mjs
@@ -7,7 +7,15 @@ const checks = [
   {
     packageName: '@flyingrobots/geordi-core',
     packageDir: 'packages/core',
-    exports: ['GEORDI_NUMERIC_PROFILE', 'isGeordiScene', 'isRectNode', 'parseJsonValue'],
+    exports: [
+      'GEORDI_BASELINE_FEATURES',
+      'GEORDI_CORE_PROFILE',
+      'GEORDI_NUMERIC_PROFILE',
+      'isGeordiFeatureRequirement',
+      'isGeordiScene',
+      'isRectNode',
+      'parseJsonValue',
+    ],
   },
   {
     packageName: '@flyingrobots/geordi-compiler-core',
@@ -22,7 +30,13 @@ const checks = [
   {
     packageName: '@flyingrobots/geordi-runtime-webgl',
     packageDir: 'packages/runtime-webgl',
-    exports: ['GEORDI_WEBGL_RUNTIME_PROFILE', 'GeordiWebGLRenderer', 'renderGeordiToCanvas'],
+    exports: [
+      'GEORDI_WEBGL_RUNTIME_PROFILE',
+      'GeordiRuntimeUnsupportedProfileError',
+      'GeordiWebGLRenderer',
+      'assertSupportedRuntimeProfile',
+      'renderGeordiToCanvas',
+    ],
   },
   {
     packageName: '@flyingrobots/geordi-wesley-generator',


### PR DESCRIPTION
## Summary

Adds an explicit baseline capability profile to the Geordi IR contract.

- Core now owns `GEORDI_CORE_PROFILE`, `GEORDI_BASELINE_FEATURES`, `GeordiFeatureRequirement`, and `requires` validation for `geordi-ir/1`.
- Compiler output includes baseline `requires`, and receipts record `featureRequirements`, `featureRequirementsHash`, and the hash algorithm.
- Runtime-webgl advertises the same feature requirements and rejects missing, malformed, or unsupported requirements before rendering.
- Package export smoke, docs, bearing, changelog, and backlog entries now reflect the capability profile contract.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (185 tests)
- `pnpm test:docs`
- `pnpm test:package-names`
- `pnpm test:repo-sludge`
- `pnpm test:placeholders`
- `pnpm test:exports`
- `git diff --check`

## Notes

This PR keeps the current baseline honest: text remains `text.raw-runtime-shaping`, so strict pixel-identical text still belongs in a follow-up feature profile rather than being implied by the baseline.