### PR TITLE
[codex] Document next slice designs

### DIFF
--- a/docs/design/2026-05-compiler-test-hardening.md
+++ b/docs/design/2026-05-compiler-test-hardening.md
@@ -1,0 +1,155 @@
+# Compiler Test Hardening Design
+
+**Status**: Draft
+**Date**: 2026-05-23
+**Slices Covered**: 8 and 9
+**GitHub Issues**: #6 and #5
+
+## Problem
+
+The next small compiler slices are not feature work. They harden type-emission tests and remove
+test-environment assumptions that can make CI or local runs misleading.
+
+The live backlog items are:
+
+- Issue #6: add coverage for the `Group` node type-emission edge case.
+- Issue #5: resolve the emitted-type `tsc` gate in a package-manager-safe way and gate the slow
+  check behind CI or an explicit local env var.
+
+## Current Evidence
+
+`TypeEmitter` emits per-kind interfaces from `KIND_PROP_TYPES`. `Group` currently has no required
+props, but it does have optional geometry and opacity props. The design issue should therefore be
+treated as the "zero required props" edge, not necessarily an empty `props` object.
+
+`emitTypes.test.ts` already resolves TypeScript through `require.resolve('typescript/bin/tsc')`.
+The remaining work for issue #5 is to add the CI/local opt-in gate while preserving CI coverage.
+
+## Goals
+
+- Pin `GroupNode` emitted shape with a dedicated test.
+- Ensure generated TypeScript typechecking still runs in CI.
+- Keep local unit tests fast unless `TSC_GATE` is set.
+- Avoid hardcoded `node_modules/.bin` paths.
+
+## Non-Goals
+
+- Do not redesign the type emitter.
+- Do not change emitted type semantics unless the new tests expose a real bug.
+- Do not remove generated-type compile coverage from CI.
+- Do not add a new package runner dependency.
+
+## Slice 8 Design: Group Zero-Required-Props Type Test
+
+### Test Shape
+
+Add a test in `packages/compiler-core/test/emitTypes.test.ts` that builds a scene with only a
+`Group` node:
+
+```ts
+const ast = makeAst({
+  nodes: [{ id: 'group', kind: 'Group', props: {} }],
+});
+```
+
+The test should assert:
+
+- `export interface GroupNode` exists.
+- `kind: "Group"` exists.
+- `props` is emitted as a valid object block.
+- The generated `SceneNode` union is exactly `GroupNode`.
+- No unrelated node interfaces are emitted.
+
+Because current `Group` props are optional rather than empty, the expected output should be pinned
+to the current contract:
+
+```ts
+export interface GroupNode {
+  id: string;
+  kind: "Group";
+  props: {
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+    rotation?: number;
+    opacity?: number;
+  };
+}
+```
+
+If implementation chooses to make `Group` truly zero-prop later, that should be a separate
+behavioral change and should update this design.
+
+### Acceptance Criteria
+
+- Dedicated `Group`-only type-emission test exists.
+- Test pins the exact expected `GroupNode` block.
+- Test proves `SceneNode = GroupNode`.
+- Compiler-core tests pass.
+
+## Slice 9 Design: CI-Gated Generated-Type TSC Check
+
+### Gate Policy
+
+Generated TypeScript should be compiled by `tsc --noEmit` when:
+
+- `process.env.CI === 'true'`
+- or `process.env.TSC_GATE === '1'`
+
+Local default test runs may skip the slow `tsc` subprocess, but they should still execute all
+pure emitter assertions.
+
+### Proposed Helper
+
+```ts
+function shouldRunGeneratedTypesTsc(): boolean {
+  return process.env.CI === 'true' || process.env.TSC_GATE === '1';
+}
+```
+
+The existing `require.resolve('typescript/bin/tsc')` resolution should remain. If ESM constraints
+make `require.resolve` unavailable in the test runtime, use `createRequire(import.meta.url)` and
+call `require.resolve` from that created require.
+
+### Test Behavior
+
+The generated-type compile test should:
+
+- Return early when the gate is disabled.
+- Write the generated `types.ts` and `tsconfig.json` to a temp directory when enabled.
+- Run the resolved TypeScript binary from the temp directory.
+- Throw `GeneratedTypesTypecheckError` with stdout/stderr if the subprocess fails.
+- Remove the temp directory in `finally`.
+
+### CI Requirement
+
+GitHub Actions should keep running the gate because `CI=true` is set in GitHub Actions by default.
+If that assumption is ever false, CI must set `TSC_GATE=1` explicitly.
+
+### Acceptance Criteria
+
+- No test shells out to `node_modules/.bin/tsc`.
+- Generated-type TSC check is skipped locally unless `TSC_GATE=1`.
+- Generated-type TSC check runs in CI.
+- Compiler-core tests pass locally.
+- PR CI proves the gated path remains covered.
+
+## Verification
+
+Local slice gates:
+
+```bash
+pnpm --filter @flyingrobots/geordi-compiler-core test
+pnpm --filter @flyingrobots/geordi-compiler-core typecheck
+pnpm --filter @flyingrobots/geordi-compiler-core lint
+```
+
+Explicit local slow gate:
+
+```bash
+TSC_GATE=1 pnpm --filter @flyingrobots/geordi-compiler-core test
+```
+
+Full PR gate remains the standard repository gate from
+[`2026-05-operating-docs-and-pr-gates.md`](./2026-05-operating-docs-and-pr-gates.md).

--- a/docs/design/2026-05-feature-registry-runtime-capabilities.md
+++ b/docs/design/2026-05-feature-registry-runtime-capabilities.md
@@ -1,0 +1,183 @@
+# Feature Registry and Runtime Capabilities Design
+
+**Status**: Draft
+**Date**: 2026-05-23
+**Slices Covered**: 3, 5, 6, and 7
+
+## Problem
+
+The current feature profile model uses `GEORDI_BASELINE_FEATURES` as both the emitted baseline and
+the complete known feature vocabulary. That worked for the first capability-profile pass, but it
+does not scale. The next strict text features must be known to core without being emitted by the
+compiler baseline and without being accepted by runtimes that do not support them.
+
+The model needs three separate concepts:
+
+- features known to this IR version
+- features emitted by the compiler baseline
+- features supported by a runtime
+
+## Goals
+
+- Split known feature vocabulary from baseline emitted requirements.
+- Keep compiler baseline output stable.
+- Rename runtime profile semantics so the runtime advertises supported features, not required
+  features.
+- Add tests for subset acceptance and unsupported optional features.
+
+## Non-Goals
+
+- Do not add strict text rendering.
+- Do not make runtime-webgl support features it cannot render.
+- Do not add best-effort fallback behavior.
+- Do not add version negotiation across multiple IR versions.
+
+## Proposed Core Model
+
+Core should expose three levels:
+
+```ts
+export const GEORDI_CORE_PROFILE = 'geordi/core/1' as const;
+
+export const GEORDI_KNOWN_FEATURES = [
+  GEORDI_CORE_PROFILE,
+  'layout.resolved',
+  'shape.group',
+  'shape.image',
+  'shape.rect',
+  'shape.text',
+  'paint.solid',
+  'stroke.solid',
+  'paint.opacity',
+  'shape.cornerRadius',
+  'text.fill',
+  'text.raw-runtime-shaping',
+  'text.fontPack',
+  'text.shapingProfile',
+  'text.lineBreakProfile',
+  'text.fallbackChain',
+  'text.glyphRuns',
+  'text.lineBoxes',
+] as const;
+
+export const GEORDI_BASELINE_FEATURES = [
+  GEORDI_CORE_PROFILE,
+  'layout.resolved',
+  'shape.group',
+  'shape.image',
+  'shape.rect',
+  'shape.text',
+  'paint.solid',
+  'stroke.solid',
+  'paint.opacity',
+  'shape.cornerRadius',
+  'text.fill',
+  'text.raw-runtime-shaping',
+] as const;
+```
+
+`GeordiFeatureRequirement` should derive from `GEORDI_KNOWN_FEATURES`, not from
+`GEORDI_BASELINE_FEATURES`.
+
+## Validation Law
+
+Core validation checks whether `ir.requires` is structurally valid for this IR version:
+
+- `requires` is an array.
+- Every entry is a string.
+- Every entry is in `GEORDI_KNOWN_FEATURES`.
+- No duplicates exist.
+- `GEORDI_CORE_PROFILE` is present.
+
+Runtime validation checks whether the runtime supports the requested subset:
+
+- Every entry in `ir.requires` appears in `runtimeProfile.supportedFeatureRequirements`.
+- Missing, malformed, or unsupported features throw `GeordiRuntimeUnsupportedProfileError`.
+- Runtime rejection happens before drawing.
+
+This preserves a useful distinction:
+
+- Unknown feature: invalid IR for this core version.
+- Known but unsupported feature: valid IR, unsupported by this runtime.
+
+## Runtime Profile Shape
+
+Preferred public shape:
+
+```ts
+interface GeordiRuntimeProfile {
+  readonly irVersion: typeof GEORDI_IR_VERSION;
+  readonly numericProfile: GeordiNumericProfile;
+  readonly supportedFeatureRequirements: readonly GeordiFeatureRequirement[];
+  readonly nodeKinds: readonly GeordiRuntimeNodeKind[];
+  readonly visualFeatures: readonly GeordiRuntimeVisualFeature[];
+}
+```
+
+The previous name, `featureRequirements`, reads as if the runtime requires features from the IR.
+The runtime actually supports a set. Because the project is still pre-v0.1, the preferred change is
+a direct rename. A compatibility alias should be added only if downstream usage forces it.
+
+## Compiler Baseline Lock
+
+Compiler-core should continue to define:
+
+```ts
+export const FEATURE_REQUIREMENTS = GEORDI_BASELINE_FEATURES;
+```
+
+Tests must prove:
+
+- `scene.geordi.json.requires` equals `GEORDI_BASELINE_FEATURES`.
+- Receipts record exactly `GEORDI_BASELINE_FEATURES`.
+- Adding known strict text features does not alter compiler output.
+
+## Slice 3 Acceptance Criteria
+
+- Core exports `GEORDI_KNOWN_FEATURES`.
+- `GeordiFeatureRequirement` derives from known features.
+- `GEORDI_BASELINE_FEATURES` remains a subset of known features.
+- Core tests prove known features, baseline features, duplicate rejection, and unknown rejection.
+
+## Slice 5 Acceptance Criteria
+
+- Runtime profile uses `supportedFeatureRequirements`.
+- Runtime-webgl profile supports the baseline feature list.
+- Runtime tests cover the new field name.
+- Package export smoke still passes.
+
+## Slice 6 Acceptance Criteria
+
+- Runtime accepts an IR whose `requires` list is a supported subset.
+- Runtime rejects a valid IR that requests known strict text features not supported by runtime-webgl.
+- Runtime still rejects unknown features through core validation or unsupported-profile checks,
+  depending on where the invalid object enters.
+
+## Slice 7 Acceptance Criteria
+
+- Compiler golden tests prove emitted IR requirements stay equal to `GEORDI_BASELINE_FEATURES`.
+- Receipt tests prove feature requirement hashes stay based on emitted baseline requirements.
+- Tests fail if future known features accidentally leak into compiler baseline output.
+
+## Risks
+
+- Renaming the runtime field may break external consumers. The repo is pre-v0.1, so direct cleanup
+  is still preferred.
+- If core accepts every future known feature too early, schema evolution can outpace implementation.
+  Only add names that have a documented failure mode.
+- If compiler baseline grows accidentally, runtimes can start rejecting previously renderable IR.
+
+## Verification
+
+Relevant gates:
+
+```bash
+pnpm --filter @flyingrobots/geordi-core test
+pnpm --filter @flyingrobots/geordi-core typecheck
+pnpm --filter @flyingrobots/geordi-core lint
+pnpm --filter @flyingrobots/geordi-runtime-webgl test
+pnpm --filter @flyingrobots/geordi-runtime-webgl typecheck
+pnpm --filter @flyingrobots/geordi-runtime-webgl lint
+pnpm --filter @flyingrobots/geordi-compiler-core test
+pnpm test:exports
+```

--- a/docs/design/2026-05-operating-docs-and-pr-gates.md
+++ b/docs/design/2026-05-operating-docs-and-pr-gates.md
@@ -1,0 +1,129 @@
+# Operating Docs and PR Gates Design
+
+**Status**: Draft
+**Date**: 2026-05-23
+**Slices Covered**: 1 and 10
+
+## Problem
+
+After each stabilization merge, the repo's operating documents can drift from the actual `main`
+state. `BEARING.md` currently records the capability-profile branch context, while the branch has
+already merged. The next implementation pass also needs a repeatable PR gate that is stricter than
+"tests seemed fine locally."
+
+## Goals
+
+- Keep `BEARING.md`, `docs/STATUS.md`, and `BACKLOG.md` aligned with `origin/main`.
+- Record the active baseline commit and next P0 direction before implementation starts.
+- Use a deterministic final gate before opening or merging PRs.
+- Keep status documents factual: completed work, current test counts, and current next moves.
+
+## Non-Goals
+
+- Do not introduce release automation.
+- Do not replace GitHub Actions.
+- Do not move backlog ownership out of `BACKLOG.md` and GitHub issues.
+- Do not make design docs the source of truth for implementation status after code lands.
+
+## Slice 1 Design: Refresh Operating Docs Post-Merge
+
+### Inputs
+
+- `git rev-parse --short origin/main`
+- `git status --porcelain=v1 -b`
+- `gh issue list --state open`
+- Current `BEARING.md`, `BACKLOG.md`, and `docs/STATUS.md`
+
+### Required Updates
+
+`BEARING.md` should record:
+
+- Current date.
+- `main` baseline commit.
+- Current branch or current operating branch.
+- Completed capability-profile work as merged, not in-progress.
+- Immediate moves in priority order.
+- Open dependency state if known.
+
+`docs/STATUS.md` should record:
+
+- Current milestone name.
+- Current package test counts after any implementation changes.
+- Complete package status.
+- Next moves that agree with `BEARING.md`.
+
+`BACKLOG.md` should record:
+
+- Completed P0 items as completed.
+- Open GitHub-backed backlog issues by number.
+- Any new P0 design item before implementation begins.
+
+### Acceptance Criteria
+
+- Docs contain no stale branch names from completed work unless used as historical context.
+- `BEARING.md` and `docs/STATUS.md` agree on next immediate moves.
+- `BACKLOG.md` agrees with `gh issue list --state open` for GitHub-backed backlog items.
+- `pnpm test:docs` passes.
+
+## Slice 10 Design: Final Gates and PR
+
+### Local Gate
+
+Before push:
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm test
+pnpm test:docs
+pnpm test:package-names
+pnpm test:repo-sludge
+pnpm test:placeholders
+pnpm test:exports
+git diff --check
+```
+
+### PR Requirements
+
+- Branch starts from current `origin/main`.
+- PR targets `main`.
+- PR body names:
+  - what changed
+  - why it changed
+  - validation commands
+  - any deliberate non-goals
+- PR should be draft unless explicitly requested otherwise.
+- CI must be green before merge.
+- CodeRabbit cooldown or review state must be checked before merge when CodeRabbit runs.
+
+### Merge Requirements
+
+Merge is allowed only when:
+
+- CI is green.
+- The branch has no unpushed local commits.
+- The worktree is clean.
+- No unresolved requested-changes review blocks remain, unless the user explicitly authorizes an
+  admin merge.
+
+### Acceptance Criteria
+
+- PR is open against `main`.
+- Local gates are recorded in the PR body.
+- GitHub checks are green or clearly reported as pending.
+- After merge, local `main` is aligned to `origin/main`.
+
+## Risks
+
+- Documentation can become performative if it is updated without checking repo state.
+- Test counts can drift if status docs are updated before the final `pnpm test`.
+- Admin merge can hide process failures if used before CI is green.
+
+## Verification
+
+The design slice itself only changes documentation, so verification is:
+
+```bash
+pnpm test:docs
+git diff --check
+```

--- a/docs/design/2026-05-strict-text-font-profile.md
+++ b/docs/design/2026-05-strict-text-font-profile.md
@@ -1,0 +1,129 @@
+# Strict Text and Font Profile Design
+
+**Status**: Draft
+**Date**: 2026-05-23
+**Slices Covered**: 2 and 4
+
+## Problem
+
+The current baseline feature profile includes `text.raw-runtime-shaping`. That is honest for the
+current renderer, but it is not enough for pixel-identical text across runtimes. Platform text
+shaping, fallback, font availability, line breaking, and metrics differ across browsers and native
+stacks.
+
+Geordi needs a strict text/font profile before it can claim deterministic text rendering.
+
+## Current State
+
+- `GEORDI_BASELINE_FEATURES` includes `text.raw-runtime-shaping`.
+- Compiler output emits the baseline requirements only.
+- Runtime-webgl shapes raw text through the canvas/runtime text stack.
+- `docs/V0_DESIGN_LAWS.md` already states that strict text requires explicit font resources,
+  shaping behavior, glyph IDs, glyph positions, and line boxes.
+
+## Goals
+
+- Add a formal P0 backlog item for strict text/font determinism.
+- Define the known strict text feature vocabulary without making it part of the emitted baseline.
+- Keep `text.raw-runtime-shaping` as the current baseline until strict text lowering exists.
+- Make future strict text requirements fail loudly in runtimes that do not support them.
+
+## Non-Goals
+
+- Do not implement HarfBuzz or a shaping engine in this slice.
+- Do not add font asset loading.
+- Do not change compiler output to glyph runs yet.
+- Do not claim pixel-identical text while raw runtime shaping remains in baseline output.
+
+## Proposed Feature Vocabulary
+
+These features should be known to core, but not emitted by the compiler baseline yet:
+
+| Feature | Meaning |
+| --- | --- |
+| `text.fontPack` | IR references concrete font resources by content identity. |
+| `text.shapingProfile` | IR declares the shaping algorithm/profile used to produce glyph output. |
+| `text.lineBreakProfile` | IR declares the line-breaking profile used before glyph placement. |
+| `text.fallbackChain` | Font fallback is explicit and ordered in IR or the asset manifest. |
+| `text.glyphRuns` | IR contains glyph IDs and positioned glyph runs instead of raw text only. |
+| `text.lineBoxes` | IR contains deterministic line boxes for hit testing and layout explainability. |
+
+The exact names may be finalized in the feature-registry slice. The important design constraint is
+that strict text is a group of explicit requirements, not an implicit upgrade to `shape.text`.
+
+## Future IR Sketch
+
+This is illustrative, not a committed API:
+
+```ts
+interface FontResource {
+  readonly id: string;
+  readonly sha256: string;
+  readonly format: 'otf' | 'ttf' | 'woff2';
+  readonly weight?: number;
+  readonly style?: 'normal' | 'italic';
+}
+
+interface GlyphRun {
+  readonly fontRef: string;
+  readonly shapingProfile: string;
+  readonly glyphs: readonly PositionedGlyph[];
+}
+
+interface PositionedGlyph {
+  readonly glyphId: number;
+  readonly cluster: number;
+  readonly x: number;
+  readonly y: number;
+  readonly advanceX: number;
+}
+```
+
+Strict text rendering should consume glyph runs and font resources. Raw `content` may remain as
+debug/source metadata, but not as the rendering input for strict compliance.
+
+## Compiler Responsibilities
+
+When strict text lowering eventually exists, compiler-core must:
+
+- Resolve logical font names to content-addressed font resources.
+- Shape text using the declared shaping profile.
+- Apply the declared line-breaking profile.
+- Emit glyph runs, line boxes, and fallback-chain evidence.
+- Add the strict text feature requirements to `ir.requires`.
+- Record relevant feature requirements in receipts.
+
+Until then, compiler-core must keep emitting only `GEORDI_BASELINE_FEATURES`.
+
+## Runtime Responsibilities
+
+A runtime that supports strict text must:
+
+- Verify every referenced font resource exists in the asset pack.
+- Render from glyph IDs and positions, not ambient runtime shaping.
+- Fail loudly if font resources, glyphs, shaping profiles, or fallback resources are missing.
+
+Runtime-webgl should reject strict text requirements until it actually supports them.
+
+## Slice 2 Acceptance Criteria
+
+- `BACKLOG.md` contains a P0 strict text/font profile item.
+- The item lists font identity, glyph runs, shaping profile, line breaking, fallback, and runtime
+  rejection behavior as acceptance criteria.
+- `docs/V0_DESIGN_LAWS.md` links the item back to the text law.
+- `pnpm test:docs` passes.
+
+## Slice 4 Acceptance Criteria
+
+- Core knows strict text feature names.
+- Baseline emitted features remain unchanged.
+- Tests prove strict text features are known but not included in `GEORDI_BASELINE_FEATURES`.
+- Runtime-webgl rejects strict text requirements unless the runtime profile explicitly supports
+  them.
+
+## Open Questions
+
+- Which shaping profile name should Geordi standardize first?
+- Should glyph positions use the current binary64 profile or a future fixed-point scalar?
+- Does strict text require a packed binary font asset format before JSON IR can claim compliance?
+- Should raw `content` remain in strict text IR for accessibility/debugging, or move to source maps?

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,58 @@
+# Geordi Design Pack
+
+**Status**: Draft
+**Date**: 2026-05-23
+**Baseline**: `main` after capability-profile merge `2dec0a5`
+
+This directory holds implementation design documents for the next post-capability-profile P0
+sequence. The design pack is intentionally separate from [`../V0_DESIGN_LAWS.md`](../V0_DESIGN_LAWS.md):
+the laws define product semantics, while these documents define the next implementation slices.
+
+## Slice Map
+
+| Slice | Working Title | Design Document |
+| ---: | --- | --- |
+| 1 | Refresh operating docs post-merge | [`2026-05-operating-docs-and-pr-gates.md`](./2026-05-operating-docs-and-pr-gates.md) |
+| 2 | Backlog strict text profile | [`2026-05-strict-text-font-profile.md`](./2026-05-strict-text-font-profile.md) |
+| 3 | Feature registry split | [`2026-05-feature-registry-runtime-capabilities.md`](./2026-05-feature-registry-runtime-capabilities.md) |
+| 4 | Strict text feature vocabulary | [`2026-05-strict-text-font-profile.md`](./2026-05-strict-text-font-profile.md) |
+| 5 | Runtime feature support model | [`2026-05-feature-registry-runtime-capabilities.md`](./2026-05-feature-registry-runtime-capabilities.md) |
+| 6 | Capability subset tests | [`2026-05-feature-registry-runtime-capabilities.md`](./2026-05-feature-registry-runtime-capabilities.md) |
+| 7 | Compiler baseline requirement lock | [`2026-05-feature-registry-runtime-capabilities.md`](./2026-05-feature-registry-runtime-capabilities.md) |
+| 8 | Issue #6: Group zero-required-props type test | [`2026-05-compiler-test-hardening.md`](./2026-05-compiler-test-hardening.md) |
+| 9 | Issue #5: CI-gated generated-type TSC check | [`2026-05-compiler-test-hardening.md`](./2026-05-compiler-test-hardening.md) |
+| 10 | Final gates and PR | [`2026-05-operating-docs-and-pr-gates.md`](./2026-05-operating-docs-and-pr-gates.md) |
+
+## Common Invariants
+
+All slices must preserve these invariants:
+
+- No rebase, amend, or force git operations.
+- One concept per commit when execution starts.
+- All production JSON ingress and egress remains behind the core JSON port.
+- All thrown errors remain custom `Error` subclasses.
+- Capability failures are hard failures, not best-effort rendering.
+- Compiler emission of baseline IR requirements must not silently grow when future known features
+  are added.
+- Local validation must include the relevant package gate plus final full gates before PR.
+
+## Full Gate
+
+The final slice should run:
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm test
+pnpm test:docs
+pnpm test:package-names
+pnpm test:repo-sludge
+pnpm test:placeholders
+pnpm test:exports
+git diff --check
+```
+
+## Non-Goals
+
+This design pack does not implement strict text shaping, matrix operation-order law, binary IR
+packing, or a CLI package. It prepares the contracts that make those later changes explicit.


### PR DESCRIPTION
## Summary

Adds a formal design pack for the next 10 planned slices after the capability-profile merge.

- Adds `docs/design/README.md` with a slice-to-design map.
- Adds operating-doc and PR gate design guidance for slice 1 and slice 10.
- Adds strict text/font profile design guidance for slices 2 and 4.
- Adds feature registry and runtime capability design guidance for slices 3, 5, 6, and 7.
- Adds compiler test hardening design guidance for issue #6 and issue #5, covering slices 8 and 9.

## Validation

- `pnpm test:docs`
- `git diff --check HEAD~1..HEAD`

## Notes

This is documentation-only. It does not implement the strict text profile, feature registry split, runtime profile rename, or compiler test changes yet.