### PR TITLE
[codex] Execute next feature-registry hit list

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -85,6 +85,31 @@ Acceptance criteria:
 
 ---
 
+### Define the strict text/font profile
+**Priority**: P0
+**Source**: v0 design laws, [`docs/design/2026-05-strict-text-font-profile.md`](./docs/design/2026-05-strict-text-font-profile.md)
+**Status**: Ready for implementation. The current baseline remains `text.raw-runtime-shaping`;
+strict text features must be known to the IR contract without being emitted by default until the
+compiler can lower text deterministically.
+
+The current renderer path lets the runtime shape raw text. That is useful for v0 rendering, but it
+cannot support a pixel-identical cross-runtime text claim because font lookup, glyph fallback,
+shaping, line breaking, and metrics vary by platform. Strict text needs an explicit profile that
+uses content-addressed fonts and precomputed glyph runs.
+
+Acceptance criteria:
+- Core owns strict text feature names for font packs, shaping profile, line-breaking profile,
+  fallback chain, glyph runs, and line boxes.
+- `GEORDI_BASELINE_FEATURES` continues to emit `text.raw-runtime-shaping` until strict text
+  lowering exists.
+- Compiler-core does not emit strict text requirements until it emits deterministic glyph runs and
+  font asset references.
+- Runtime profiles reject strict text requirements unless the runtime supports the full strict text
+  contract.
+- Receipts continue to record the exact feature requirements emitted by the compiler.
+
+---
+
 ## Completed Stabilization Work
 
 These P0 items were completed in the 2026-05-22 stabilization work and are retained here as

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -185,6 +185,7 @@ Target package: `@flyingrobots/geordi-compiler-core`. Add `fast-check` as a dev 
 
 ### `emitTypes` test — CI-gated TSC typecheck
 **Issue**: [#5](https://github.com/flyingrobots/geordi/issues/5)
+**Status**: Implemented in `codex/execute-next-hit-list`; closes when the PR merges.
 
 `emitTypes.test.ts` shells out to `node_modules/.bin/tsc` with a hardcoded path that breaks
 under PNP or hoisted workspace setups. Fix by resolving via `require.resolve('typescript/bin/tsc')`
@@ -194,6 +195,7 @@ and gate the slow typecheck behind `process.env.CI || process.env.TSC_GATE` so l
 
 ### `emitTypes` test — Group-kind zero-props interface
 **Issue**: [#6](https://github.com/flyingrobots/geordi/issues/6)
+**Status**: Implemented in `codex/execute-next-hit-list`; closes when the PR merges.
 
 No test asserts that a scene containing only `Group` nodes emits a valid `GroupNode` interface
 with an empty `props` block. This is an edge case in `TypeEmitter.emitKindInterface` where
@@ -212,7 +214,8 @@ catches it and converts to a diagnostic but loses the GraphQL source location (`
 from the original `ParseError`. Propagate the location into `Diagnostic.details` so callers can
 report precise SDL error positions to users.
 
-Open GitHub-backed backlog after this reconciliation: #2, #3, #4, #5, and #6 remain active.
+Open GitHub-backed backlog after this reconciliation: #2, #3, and #4 remain active after the
+current PR merges.
 
 ---
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -87,7 +87,8 @@ Acceptance criteria:
 
 ### Define the strict text/font profile
 **Priority**: P0
-**Source**: v0 design laws, [`docs/design/2026-05-strict-text-font-profile.md`](./docs/design/2026-05-strict-text-font-profile.md)
+**Source**: v0 design laws,
+[`docs/design/2026-05-strict-text-font-profile.md`](./docs/design/2026-05-strict-text-font-profile.md)
 **Status**: Ready for implementation. The current baseline remains `text.raw-runtime-shaping`;
 strict text features must be known to the IR contract without being emitted by default until the
 compiler can lower text deterministically.

--- a/BEARING.md
+++ b/BEARING.md
@@ -1,8 +1,8 @@
 # Geordi Bearing
 
 **Date**: 2026-05-23
-**Branch baseline**: `main` at `fce5978`
-**Current branch when written**: `p0/capability-profile-contract`
+**Branch baseline**: `main` at `1719019`
+**Current branch when written**: `codex/execute-next-hit-list`
 
 This file is the short-term operating map. Product rationale remains in
 [`docs/V0_DESIGN_LAWS.md`](./docs/V0_DESIGN_LAWS.md); detailed work items remain in
@@ -57,6 +57,8 @@ Completed:
 - Compiler-core exposes a deterministic diagnostic formatter, and the Wesley generator uses it for
   stable logging.
 - Root `pnpm wesley` shells out to the installed Wesley CLI.
+- The next post-capability-profile slice sequence has a formal design pack in
+  [`docs/design/`](./docs/design/).
 
 Still true:
 
@@ -74,10 +76,12 @@ Still true:
 
 ## Recommended P0 Order
 
-1. Define the next strict text/font feature profile beyond the current v0 baseline.
-2. Decide whether Wesley modernization should target `wesley-cli`/`wesley-core` 0.0.5 through a
+1. Execute the strict text/font profile and feature-registry split described in
+   [`docs/design/`](./docs/design/).
+2. Close GitHub issues #6 and #5 as the first compiler test-hardening cleanup.
+3. Decide whether Wesley modernization should target `wesley-cli`/`wesley-core` 0.0.5 through a
    CLI boundary, Rust workspace boundary, or future npm/WASM boundary.
-3. Keep dependency hygiene clean; there are no open PRs at the time this bearing was refreshed.
+4. Keep dependency hygiene clean; there are no open PRs at the time this bearing was refreshed.
 
 ## Dependency Work
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@
 - **`@flyingrobots/geordi-runtime-webgl`**: Add baseline feature requirements to
   `GEORDI_WEBGL_RUNTIME_PROFILE` and fail loudly when IR omits `requires` or asks for unsupported
   features.
+- **`@flyingrobots/geordi-core`**: Split known feature requirements from baseline emitted feature
+  requirements and add strict text feature vocabulary for future deterministic font/glyph work.
+- **`@flyingrobots/geordi-runtime-webgl`**: Rename the runtime profile feature field to
+  `supportedFeatureRequirements` and keep strict text requirements unsupported until the runtime
+  can honor the full strict text contract.
 - **Public API**: De-version the current IR TypeScript surface (`GeordiIr`,
   `validateGeordiIr()`, `isGeordiIr()`) and compiler target (`geordi-ir`) while preserving
   `irVersion: "geordi-ir/1"` as the serialized contract identity.
@@ -90,6 +95,12 @@
   compiler golden coverage for emitted requirements and receipt hashes, runtime rejection coverage
   for missing, malformed, and unsupported feature requirements, and package export smoke coverage
   for public capability symbols.
+- **Feature registry**: add core coverage proving strict text features are known but not baseline,
+  compiler coverage proving emitted IR and receipts stay locked to baseline requirements, and
+  runtime coverage for supported subsets plus known-but-unsupported strict text requirements.
+- **`@flyingrobots/geordi-compiler-core`**: add Group-only type-emission coverage and gate the
+  generated-type `tsc` subprocess behind CI or `TSC_GATE=1` while resolving TypeScript through the
+  package entrypoint.
 - **`@flyingrobots/geordi-compiler-core`**: add source-location model, diagnostic formatter, and
   source-map artifact coverage.
 - **`@flyingrobots/geordi-schema-graphql`**: add exact GraphQL source-span tests and an e2e source

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -136,7 +136,7 @@ Immediate:
 
 Short term:
 
-5. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
+1. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
 
 ## Decision Log
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-05-23
 **Version**: 0.1.0-dev
-**Milestone**: Capability profile contract work starting from `main` at `fce5978`
+**Milestone**: Next slice execution starting from `main` at `1719019`
 
 See [`../BEARING.md`](../BEARING.md) for the current operating map.
 
@@ -87,6 +87,7 @@ Canvas-backed WebGL-runtime scaffold.
 - GitHub Actions CI.
 - Dependabot grouped updates for npm workspace dependencies and GitHub Actions.
 - Strict TypeScript and type-aware ESLint.
+- Formal design pack for the next P0 slice sequence in `docs/design/`.
 - Root hygiene gates:
   - `pnpm test:exports`
   - `pnpm test:package-names`
@@ -96,7 +97,7 @@ Canvas-backed WebGL-runtime scaffold.
 
 ## Test Status
 
-Latest package test counts for the capability-profile branch:
+Latest package test counts after the capability-profile and design-pack merges:
 
 | Package | Tests | Status |
 | --- | ---: | --- |
@@ -122,14 +123,15 @@ Additional gates:
 Immediate:
 
 1. Define the next strict text/font profile beyond `text.raw-runtime-shaping`.
-2. Specify deterministic operation-order rules for future vector, matrix, transform, and animation
+2. Split known feature vocabulary from compiler-emitted baseline requirements.
+3. Specify deterministic operation-order rules for future vector, matrix, transform, and animation
    math.
-3. Keep source-map, diagnostic formatter, and receipt behavior wired into future CLI/Wesley
+4. Keep source-map, diagnostic formatter, and receipt behavior wired into future CLI/Wesley
    entrypoints.
 
 Short term:
 
-4. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
+5. Create `@flyingrobots/geordi-cli` for compile, validate, pack, and watch workflows.
 
 ## Decision Log
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -25,10 +25,14 @@ Pure, framework-agnostic compilation engine.
 - Deterministic IR, receipt, source-map, and TypeScript type emission.
 - IR and receipt emission declare the v0 numeric profile, baseline feature requirements, and
   feature-requirement hash.
+- Compiler tests lock emitted IR and receipt requirements to the baseline set even as core knows
+  future feature names.
 - Current public IR API names are `GeordiIr`, `validateGeordiIr()`, and `isGeordiIr()`; versioning
   remains in serialized contract values such as `irVersion: "geordi-ir/1"`.
 - Canonical source-location model shared by AST source refs and diagnostics.
 - Deterministic diagnostic formatter for stable CLI/adapter output.
+- Type-emission tests cover Group-only scenes, and the generated-type `tsc` subprocess runs only in
+  CI or with `TSC_GATE=1`.
 - Post-build public export smoke coverage.
 
 #### `@flyingrobots/geordi-schema-graphql`
@@ -60,8 +64,8 @@ Core domain package.
 - Canonical JSON port with deterministic parse/stringify/normalize behavior and custom JSON
   errors.
 - v0 numeric profile constant `geordi-finite-binary64/1` and graphics-number helpers.
-- Baseline feature profile constants rooted at `geordi/core/1`, plus validation for
-  `geordi-ir/1` `requires`.
+- Known feature registry, baseline feature profile constants rooted at `geordi/core/1`, strict text
+  feature vocabulary, and validation for `geordi-ir/1` `requires`.
 - Current `GeordiIr` structural types and validation for the `geordi-ir/1` payload contract.
 - Draw-ready runtime scene aliases named `PreparedGeordiScene` and `PreparedGeordiNode`.
 - Compatibility aliases for the older scene names remain during the v0.1 migration.
@@ -75,9 +79,10 @@ Canvas-backed WebGL-runtime scaffold.
 - `renderGeordiToCanvas()` is the primary public `geordi-ir/1` rendering API.
 - `renderPreparedSceneToCanvas()` renders draw-ready runtime scenes explicitly.
 - Runtime-bound IR validation and fail-loud prop lowering use custom runtime error types.
-- Runtime capability profile declares supported IR version, numeric profile, feature requirements,
-  node kinds, and visual features.
-- Runtime profile checks reject missing or unsupported feature requirements before drawing.
+- Runtime capability profile declares supported IR version, numeric profile, supported feature
+  requirements, node kinds, and visual features.
+- Runtime profile checks render supported requirement subsets and reject missing, malformed,
+  unknown, or known-but-unsupported strict text requirements before drawing.
 - Compiler-emitted IR is rendered through the runtime contract in an integration test.
 
 ## Infrastructure
@@ -97,16 +102,16 @@ Canvas-backed WebGL-runtime scaffold.
 
 ## Test Status
 
-Latest package test counts after the capability-profile and design-pack merges:
+Latest package test counts after the next-slice hit list:
 
 | Package | Tests | Status |
 | --- | ---: | --- |
-| `@flyingrobots/geordi-compiler-core` | 82 | Green |
+| `@flyingrobots/geordi-compiler-core` | 84 | Green |
 | `@flyingrobots/geordi-schema-graphql` | 55 | Green |
-| `@flyingrobots/geordi-core` | 30 | Green |
-| `@flyingrobots/geordi-runtime-webgl` | 15 | Green |
+| `@flyingrobots/geordi-core` | 32 | Green |
+| `@flyingrobots/geordi-runtime-webgl` | 17 | Green |
 | `@flyingrobots/geordi-wesley-generator` | 3 | Green |
-| **Total package tests** | **185** | Green |
+| **Total package tests** | **191** | Green |
 
 Additional gates:
 
@@ -122,11 +127,11 @@ Additional gates:
 
 Immediate:
 
-1. Define the next strict text/font profile beyond `text.raw-runtime-shaping`.
-2. Split known feature vocabulary from compiler-emitted baseline requirements.
-3. Specify deterministic operation-order rules for future vector, matrix, transform, and animation
+1. Specify deterministic operation-order rules for future vector, matrix, transform, and animation
    math.
-4. Keep source-map, diagnostic formatter, and receipt behavior wired into future CLI/Wesley
+2. Move to the next GitHub-backed compiler backlog items: artifact builder (#3), identifier-map
+   API cleanup (#2), and validation fuzzing (#4).
+3. Keep source-map, diagnostic formatter, and receipt behavior wired into future CLI/Wesley
    entrypoints.
 
 Short term:

--- a/docs/V0_DESIGN_LAWS.md
+++ b/docs/V0_DESIGN_LAWS.md
@@ -475,6 +475,18 @@ requirements in `scene.geordi.json` and records them plus `featureRequirementsHa
 `runtime-webgl` declares the same feature requirements in `GEORDI_WEBGL_RUNTIME_PROFILE` and
 rejects missing or unsupported requirements.
 
+### P0: Define the strict text/font profile
+
+Raw runtime text shaping is allowed in the current baseline only as an honest v0 rendering mode.
+It is not a pixel-identical cross-runtime compliance claim. Strict text needs a separate profile
+that requires content-addressed font packs, a declared shaping profile, a declared line-breaking
+profile, explicit fallback chains, glyph runs, and line boxes.
+
+**Status**: Ready for implementation. See
+[`docs/design/2026-05-strict-text-font-profile.md`](./design/2026-05-strict-text-font-profile.md)
+for the implementation plan. The compiler must keep emitting `text.raw-runtime-shaping` until it
+can lower text into deterministic glyph data.
+
 ### P0: Validate GraphQL directive argument types at runtime
 
 Replace unsafe directive argument casts with typed extractors that emit source-located `GEORDI_E_DIRECTIVE_ARG_INVALID_TYPE` diagnostics.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -2,7 +2,7 @@
 
 **Status**: Draft
 **Date**: 2026-05-23
-**Baseline**: `main` after capability-profile merge `2dec0a5`
+**Baseline**: `main` after design-pack merge `1719019`
 
 This directory holds implementation design documents for the next post-capability-profile P0
 sequence. The design pack is intentionally separate from [`../V0_DESIGN_LAWS.md`](../V0_DESIGN_LAWS.md):

--- a/packages/compiler-core/test/compile.golden.test.ts
+++ b/packages/compiler-core/test/compile.golden.test.ts
@@ -1,6 +1,10 @@
 import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
-import { GEORDI_BASELINE_FEATURES, GEORDI_NUMERIC_PROFILE } from '@flyingrobots/geordi-core';
+import {
+  GEORDI_BASELINE_FEATURES,
+  GEORDI_KNOWN_FEATURES,
+  GEORDI_NUMERIC_PROFILE,
+} from '@flyingrobots/geordi-core';
 import { compile } from '../src/compile/compile';
 import { GeordiErrorCode } from '../src/errors';
 import { parseJsonValue, stringifyCanonicalJson } from '../src/ports/json';
@@ -66,6 +70,8 @@ describe('compile() golden path', () => {
     expect(ir.irVersion).toBe('geordi-ir/1');
     expect(ir.numericProfile).toBe(GEORDI_NUMERIC_PROFILE);
     expect(ir.requires).toEqual(GEORDI_BASELINE_FEATURES);
+    expect(ir.requires).not.toEqual(GEORDI_KNOWN_FEATURES);
+    expect(ir.requires).not.toContain('text.glyphRuns');
     expect(ir.scene.id).toBe('scene:terminal');
     expect(Array.isArray(ir.nodes)).toBe(true);
     expect(ir.nodes.length).toBe(2);
@@ -110,6 +116,7 @@ describe('compile() golden path', () => {
     const receipt = parseJsonValue(String(result.artifacts['scene.geordi.json.receipt'].content)) as JsonObject;
     expect(receipt.comparatorVersion).toBe('1');
     expect(receipt.featureRequirements).toEqual(GEORDI_BASELINE_FEATURES);
+    expect(receipt.featureRequirements).not.toEqual(GEORDI_KNOWN_FEATURES);
     expect(receipt.featureRequirementsHash).toBe(
       sha256(GEORDI_BASELINE_FEATURES.join('\n')),
     );

--- a/packages/compiler-core/test/compile.golden.test.ts
+++ b/packages/compiler-core/test/compile.golden.test.ts
@@ -4,6 +4,7 @@ import {
   GEORDI_BASELINE_FEATURES,
   GEORDI_KNOWN_FEATURES,
   GEORDI_NUMERIC_PROFILE,
+  GEORDI_STRICT_TEXT_FEATURES,
 } from '@flyingrobots/geordi-core';
 import { compile } from '../src/compile/compile';
 import { GeordiErrorCode } from '../src/errors';
@@ -71,7 +72,9 @@ describe('compile() golden path', () => {
     expect(ir.numericProfile).toBe(GEORDI_NUMERIC_PROFILE);
     expect(ir.requires).toEqual(GEORDI_BASELINE_FEATURES);
     expect(ir.requires).not.toEqual(GEORDI_KNOWN_FEATURES);
-    expect(ir.requires).not.toContain('text.glyphRuns');
+    for (const feature of GEORDI_STRICT_TEXT_FEATURES) {
+      expect(ir.requires).not.toContain(feature);
+    }
     expect(ir.scene.id).toBe('scene:terminal');
     expect(Array.isArray(ir.nodes)).toBe(true);
     expect(ir.nodes.length).toBe(2);
@@ -117,6 +120,9 @@ describe('compile() golden path', () => {
     expect(receipt.comparatorVersion).toBe('1');
     expect(receipt.featureRequirements).toEqual(GEORDI_BASELINE_FEATURES);
     expect(receipt.featureRequirements).not.toEqual(GEORDI_KNOWN_FEATURES);
+    for (const feature of GEORDI_STRICT_TEXT_FEATURES) {
+      expect(receipt.featureRequirements).not.toContain(feature);
+    }
     expect(receipt.featureRequirementsHash).toBe(
       sha256(GEORDI_BASELINE_FEATURES.join('\n')),
     );

--- a/packages/compiler-core/test/coreIrContract.test.ts
+++ b/packages/compiler-core/test/coreIrContract.test.ts
@@ -3,6 +3,7 @@ import {
   GEORDI_BASELINE_FEATURES,
   GEORDI_KNOWN_FEATURES,
   GEORDI_NUMERIC_PROFILE,
+  GEORDI_STRICT_TEXT_FEATURES,
   validateGeordiIr,
 } from '@flyingrobots/geordi-core';
 import type { GeordiIr } from '@flyingrobots/geordi-core';
@@ -59,5 +60,8 @@ describe('compiler-core to geordi-core IR contract', () => {
     expect((ir as GeordiIr).numericProfile).toBe(GEORDI_NUMERIC_PROFILE);
     expect((ir as GeordiIr).requires).toEqual(GEORDI_BASELINE_FEATURES);
     expect((ir as GeordiIr).requires).not.toEqual(GEORDI_KNOWN_FEATURES);
+    for (const feature of GEORDI_STRICT_TEXT_FEATURES) {
+      expect((ir as GeordiIr).requires).not.toContain(feature);
+    }
   });
 });

--- a/packages/compiler-core/test/coreIrContract.test.ts
+++ b/packages/compiler-core/test/coreIrContract.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   GEORDI_BASELINE_FEATURES,
+  GEORDI_KNOWN_FEATURES,
   GEORDI_NUMERIC_PROFILE,
   validateGeordiIr,
 } from '@flyingrobots/geordi-core';
@@ -57,5 +58,6 @@ describe('compiler-core to geordi-core IR contract', () => {
     expect(validateGeordiIr(ir)).toEqual({ ok: true, issues: [] });
     expect((ir as GeordiIr).numericProfile).toBe(GEORDI_NUMERIC_PROFILE);
     expect((ir as GeordiIr).requires).toEqual(GEORDI_BASELINE_FEATURES);
+    expect((ir as GeordiIr).requires).not.toEqual(GEORDI_KNOWN_FEATURES);
   });
 });

--- a/packages/compiler-core/test/emitTypes.test.ts
+++ b/packages/compiler-core/test/emitTypes.test.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -16,6 +17,11 @@ import type { JsonObject } from '../src/types/json';
 interface ExecSyncFailure {
   stdout?: string | Uint8Array;
   stderr?: string | Uint8Array;
+}
+
+interface GeneratedTypesTscGateEnv {
+  readonly CI?: string;
+  readonly TSC_GATE?: string;
 }
 
 class GeneratedTypesTypecheckError extends Error {
@@ -35,6 +41,10 @@ function outputText(value: string | Uint8Array | undefined): string {
   }
 
   return typeof value === 'string' ? value : Buffer.from(value).toString('utf8');
+}
+
+function shouldRunGeneratedTypesTsc(env: GeneratedTypesTscGateEnv = process.env): boolean {
+  return env.CI === 'true' || env.TSC_GATE === '1';
 }
 
 function makeAst(partial: Partial<CanonicalSceneAst> = {}): CanonicalSceneAst {
@@ -219,7 +229,18 @@ describe('TypeEmitter', () => {
     expect(source).not.toContain(forbiddenOption);
   });
 
+  it('generated typecheck gate runs only in CI or by explicit opt-in', () => {
+    expect(shouldRunGeneratedTypesTsc({})).toBe(false);
+    expect(shouldRunGeneratedTypesTsc({ CI: 'false', TSC_GATE: '0' })).toBe(false);
+    expect(shouldRunGeneratedTypesTsc({ CI: 'true' })).toBe(true);
+    expect(shouldRunGeneratedTypesTsc({ TSC_GATE: '1' })).toBe(true);
+  });
+
   it('emitted TypeScript passes tsc --noEmit (C3 success gate)', () => {
+    if (!shouldRunGeneratedTypesTsc()) {
+      return;
+    }
+
     const ast = makeAst({
       nodes: [
         // 'type' is a reserved keyword — identifier guard must fire
@@ -249,7 +270,8 @@ describe('TypeEmitter', () => {
       writeFileSync(join(dir, 'tsconfig.json'), stringifyCanonicalJson(tsconfig), 'utf8');
       writeFileSync(file, output, 'utf8');
       // Run tsc in the temporary directory
-      const tscPath = require.resolve('typescript/bin/tsc');
+      const requireFromTest = createRequire(import.meta.url);
+      const tscPath = requireFromTest.resolve('typescript/bin/tsc');
       execSync(tscPath, {
         cwd: dir,
         encoding: 'utf8',

--- a/packages/compiler-core/test/emitTypes.test.ts
+++ b/packages/compiler-core/test/emitTypes.test.ts
@@ -173,6 +173,31 @@ describe('TypeEmitter', () => {
     expect(output).toContain('export interface PathNode');
   });
 
+  it('Group-only scenes emit a valid zero-required-props GroupNode interface', () => {
+    const ast = makeAst({
+      nodes: [{ id: 'group', kind: 'Group', props: {} }],
+    });
+    const output = new TypeEmitter(ast).emit();
+
+    expect(output).toContain('export type NodeId = "group";');
+    expect(output).toContain(`export interface GroupNode {
+  id: string;
+  kind: "Group";
+  props: {
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+    rotation?: number;
+    opacity?: number;
+  };
+}
+`);
+    expect(output).toContain('export type SceneNode = GroupNode;');
+    expect(output).not.toContain('export interface RectNode');
+    expect(output).not.toContain('export interface TextNode');
+  });
+
   it('SceneRoot always present with required fields', () => {
     const ast = makeAst();
     const output = new TypeEmitter(ast).emit();

--- a/packages/core/src/domain/models/GeordiFeatureProfile.test.ts
+++ b/packages/core/src/domain/models/GeordiFeatureProfile.test.ts
@@ -3,6 +3,7 @@ import {
   GEORDI_BASELINE_FEATURES,
   GEORDI_CORE_PROFILE,
   GEORDI_KNOWN_FEATURES,
+  GEORDI_STRICT_TEXT_FEATURES,
   isGeordiFeatureRequirement,
 } from './GeordiFeatureProfile';
 
@@ -28,12 +29,28 @@ describe('Geordi feature profile', () => {
     ]);
   });
 
-  it('keeps baseline features inside the known feature registry', () => {
-    expect(GEORDI_KNOWN_FEATURES).toEqual(GEORDI_BASELINE_FEATURES);
+  it('declares a deterministic strict text feature list', () => {
+    expect(GEORDI_STRICT_TEXT_FEATURES).toEqual([
+      'text.fontPack',
+      'text.shapingProfile',
+      'text.lineBreakProfile',
+      'text.fallbackChain',
+      'text.glyphRuns',
+      'text.lineBoxes',
+    ]);
+  });
+
+  it('keeps baseline and strict text features inside the known feature registry', () => {
+    expect(GEORDI_KNOWN_FEATURES).toEqual([
+      ...GEORDI_BASELINE_FEATURES,
+      ...GEORDI_STRICT_TEXT_FEATURES,
+    ]);
+    expect(GEORDI_BASELINE_FEATURES).not.toContain('text.glyphRuns');
   });
 
   it('classifies known feature requirements', () => {
     expect(isGeordiFeatureRequirement('shape.rect')).toBe(true);
+    expect(isGeordiFeatureRequirement('text.glyphRuns')).toBe(true);
     expect(isGeordiFeatureRequirement('effect.blur/1')).toBe(false);
   });
 });

--- a/packages/core/src/domain/models/GeordiFeatureProfile.test.ts
+++ b/packages/core/src/domain/models/GeordiFeatureProfile.test.ts
@@ -45,7 +45,9 @@ describe('Geordi feature profile', () => {
       ...GEORDI_BASELINE_FEATURES,
       ...GEORDI_STRICT_TEXT_FEATURES,
     ]);
-    expect(GEORDI_BASELINE_FEATURES).not.toContain('text.glyphRuns');
+    for (const feature of GEORDI_STRICT_TEXT_FEATURES) {
+      expect(GEORDI_BASELINE_FEATURES).not.toContain(feature);
+    }
   });
 
   it('classifies known feature requirements', () => {

--- a/packages/core/src/domain/models/GeordiFeatureProfile.test.ts
+++ b/packages/core/src/domain/models/GeordiFeatureProfile.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   GEORDI_BASELINE_FEATURES,
   GEORDI_CORE_PROFILE,
+  GEORDI_KNOWN_FEATURES,
   isGeordiFeatureRequirement,
 } from './GeordiFeatureProfile';
 
@@ -27,7 +28,11 @@ describe('Geordi feature profile', () => {
     ]);
   });
 
-  it('classifies supported feature requirements', () => {
+  it('keeps baseline features inside the known feature registry', () => {
+    expect(GEORDI_KNOWN_FEATURES).toEqual(GEORDI_BASELINE_FEATURES);
+  });
+
+  it('classifies known feature requirements', () => {
     expect(isGeordiFeatureRequirement('shape.rect')).toBe(true);
     expect(isGeordiFeatureRequirement('effect.blur/1')).toBe(false);
   });

--- a/packages/core/src/domain/models/GeordiFeatureProfile.ts
+++ b/packages/core/src/domain/models/GeordiFeatureProfile.ts
@@ -15,12 +15,14 @@ export const GEORDI_BASELINE_FEATURES = [
   'text.raw-runtime-shaping',
 ] as const;
 
-export type GeordiFeatureRequirement = (typeof GEORDI_BASELINE_FEATURES)[number];
+export const GEORDI_KNOWN_FEATURES = [...GEORDI_BASELINE_FEATURES] as const;
 
-const GEORDI_BASELINE_FEATURE_SET = new Set<string>(GEORDI_BASELINE_FEATURES);
+export type GeordiFeatureRequirement = (typeof GEORDI_KNOWN_FEATURES)[number];
+
+const GEORDI_KNOWN_FEATURE_SET = new Set<string>(GEORDI_KNOWN_FEATURES);
 
 export function isGeordiFeatureRequirement(
   value: string,
 ): value is GeordiFeatureRequirement {
-  return GEORDI_BASELINE_FEATURE_SET.has(value);
+  return GEORDI_KNOWN_FEATURE_SET.has(value);
 }

--- a/packages/core/src/domain/models/GeordiFeatureProfile.ts
+++ b/packages/core/src/domain/models/GeordiFeatureProfile.ts
@@ -15,7 +15,19 @@ export const GEORDI_BASELINE_FEATURES = [
   'text.raw-runtime-shaping',
 ] as const;
 
-export const GEORDI_KNOWN_FEATURES = [...GEORDI_BASELINE_FEATURES] as const;
+export const GEORDI_STRICT_TEXT_FEATURES = [
+  'text.fontPack',
+  'text.shapingProfile',
+  'text.lineBreakProfile',
+  'text.fallbackChain',
+  'text.glyphRuns',
+  'text.lineBoxes',
+] as const;
+
+export const GEORDI_KNOWN_FEATURES = [
+  ...GEORDI_BASELINE_FEATURES,
+  ...GEORDI_STRICT_TEXT_FEATURES,
+] as const;
 
 export type GeordiFeatureRequirement = (typeof GEORDI_KNOWN_FEATURES)[number];
 

--- a/packages/core/src/domain/models/index.ts
+++ b/packages/core/src/domain/models/index.ts
@@ -55,6 +55,7 @@ export { isPreparedGeordiScene, isGeordiScene } from './GeordiScene.js';
 export {
   GEORDI_BASELINE_FEATURES,
   GEORDI_CORE_PROFILE,
+  GEORDI_KNOWN_FEATURES,
   isGeordiFeatureRequirement,
 } from './GeordiFeatureProfile.js';
 

--- a/packages/core/src/domain/models/index.ts
+++ b/packages/core/src/domain/models/index.ts
@@ -56,6 +56,7 @@ export {
   GEORDI_BASELINE_FEATURES,
   GEORDI_CORE_PROFILE,
   GEORDI_KNOWN_FEATURES,
+  GEORDI_STRICT_TEXT_FEATURES,
   isGeordiFeatureRequirement,
 } from './GeordiFeatureProfile.js';
 

--- a/packages/runtime-webgl/src/index.test.ts
+++ b/packages/runtime-webgl/src/index.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   GEORDI_BASELINE_FEATURES,
+  GEORDI_CORE_PROFILE,
   GEORDI_NUMERIC_PROFILE,
+  GEORDI_STRICT_TEXT_FEATURES,
   isGeordiIr,
   type GeordiIr,
   type PreparedGeordiScene,
@@ -295,6 +297,21 @@ describe('runtime-webgl public API', () => {
     expect(context.font).toBe('400 12px Inter');
   });
 
+  it('renders IR that requires a supported feature subset', () => {
+    const context = new FakeCanvasContext2D();
+    const canvas = makeCanvas(context as object as CanvasRenderingContext2D);
+    installCanvasDocument(canvas);
+
+    const rendered = renderGeordiToCanvas({
+      ...makeIr(),
+      requires: [GEORDI_CORE_PROFILE, 'shape.rect'],
+    });
+
+    expect(rendered).toBe(canvas);
+    expect(canvas.width).toBe(100);
+    expect(canvas.height).toBe(50);
+  });
+
   it('keeps the deprecated IR helper as a compatibility alias', () => {
     expect(renderGeordiIrToCanvas).toBe(renderGeordiToCanvas);
   });
@@ -330,6 +347,17 @@ describe('runtime-webgl public API', () => {
     } as object as GeordiIr;
 
     expect(() => renderGeordiToCanvas(unsupportedFeatureIr)).toThrow(
+      GeordiRuntimeUnsupportedProfileError,
+    );
+  });
+
+  it('throws a custom error for known strict text requirements until supported', () => {
+    const strictTextIr: GeordiIr = {
+      ...makeIr(),
+      requires: [...GEORDI_BASELINE_FEATURES, ...GEORDI_STRICT_TEXT_FEATURES],
+    };
+
+    expect(() => renderGeordiToCanvas(strictTextIr)).toThrow(
       GeordiRuntimeUnsupportedProfileError,
     );
   });

--- a/packages/runtime-webgl/src/index.test.ts
+++ b/packages/runtime-webgl/src/index.test.ts
@@ -305,7 +305,7 @@ describe('runtime-webgl public API', () => {
     const ir = makeIr();
     const rendered = renderGeordiToCanvas({
       ...ir,
-      requires: [GEORDI_CORE_PROFILE, 'shape.rect'],
+      requires: [GEORDI_CORE_PROFILE, 'layout.resolved', 'shape.rect', 'paint.solid'],
       nodes: ir.nodes.filter((node) => node.kind === 'Rect'),
     });
 

--- a/packages/runtime-webgl/src/index.test.ts
+++ b/packages/runtime-webgl/src/index.test.ts
@@ -239,7 +239,7 @@ describe('runtime-webgl public API', () => {
     expect(GEORDI_WEBGL_RUNTIME_PROFILE).toEqual({
       irVersion: 'geordi-ir/1',
       numericProfile: GEORDI_NUMERIC_PROFILE,
-      featureRequirements: GEORDI_BASELINE_FEATURES,
+      supportedFeatureRequirements: GEORDI_BASELINE_FEATURES,
       nodeKinds: ['Rect', 'Text', 'Group', 'Image'],
       visualFeatures: ['solid-fill', 'solid-stroke', 'opacity', 'corner-radius', 'text-fill'],
     });

--- a/packages/runtime-webgl/src/index.test.ts
+++ b/packages/runtime-webgl/src/index.test.ts
@@ -302,14 +302,17 @@ describe('runtime-webgl public API', () => {
     const canvas = makeCanvas(context as object as CanvasRenderingContext2D);
     installCanvasDocument(canvas);
 
+    const ir = makeIr();
     const rendered = renderGeordiToCanvas({
-      ...makeIr(),
+      ...ir,
       requires: [GEORDI_CORE_PROFILE, 'shape.rect'],
+      nodes: ir.nodes.filter((node) => node.kind === 'Rect'),
     });
 
     expect(rendered).toBe(canvas);
     expect(canvas.width).toBe(100);
     expect(canvas.height).toBe(50);
+    expect(context.calls.some((call) => call.name === 'fillText')).toBe(false);
   });
 
   it('keeps the deprecated IR helper as a compatibility alias', () => {

--- a/packages/runtime-webgl/src/profile.ts
+++ b/packages/runtime-webgl/src/profile.ts
@@ -18,7 +18,7 @@ export type GeordiRuntimeVisualFeature =
 export interface GeordiRuntimeProfile {
   readonly irVersion: typeof GEORDI_IR_VERSION;
   readonly numericProfile: GeordiNumericProfile;
-  readonly featureRequirements: readonly GeordiFeatureRequirement[];
+  readonly supportedFeatureRequirements: readonly GeordiFeatureRequirement[];
   readonly nodeKinds: readonly GeordiRuntimeNodeKind[];
   readonly visualFeatures: readonly GeordiRuntimeVisualFeature[];
 }
@@ -26,7 +26,7 @@ export interface GeordiRuntimeProfile {
 export const GEORDI_WEBGL_RUNTIME_PROFILE: GeordiRuntimeProfile = {
   irVersion: GEORDI_IR_VERSION,
   numericProfile: GEORDI_NUMERIC_PROFILE,
-  featureRequirements: GEORDI_BASELINE_FEATURES,
+  supportedFeatureRequirements: GEORDI_BASELINE_FEATURES,
   nodeKinds: ['Rect', 'Text', 'Group', 'Image'],
   visualFeatures: ['solid-fill', 'solid-stroke', 'opacity', 'corner-radius', 'text-fill'],
 };
@@ -70,23 +70,23 @@ export function assertSupportedRuntimeProfile(
   if (!Array.isArray(ir.requires)) {
     throw new GeordiRuntimeUnsupportedProfileError(
       'requires=<missing>',
-      `requires=${profile.featureRequirements.join(',')}`,
+      `requires=${profile.supportedFeatureRequirements.join(',')}`,
     );
   }
 
-  const supportedFeatureRequirements = new Set<string>(profile.featureRequirements);
+  const supportedFeatureRequirements = new Set<string>(profile.supportedFeatureRequirements);
   for (const [index, requirement] of ir.requires.entries()) {
     if (typeof requirement !== 'string') {
       throw new GeordiRuntimeUnsupportedProfileError(
         `requires[${index}]=${String(requirement)}`,
-        `requires=${profile.featureRequirements.join(',')}`,
+        `requires=${profile.supportedFeatureRequirements.join(',')}`,
       );
     }
 
     if (!supportedFeatureRequirements.has(requirement)) {
       throw new GeordiRuntimeUnsupportedProfileError(
         `requires=${requirement}`,
-        `requires=${profile.featureRequirements.join(',')}`,
+        `requires=${profile.supportedFeatureRequirements.join(',')}`,
       );
     }
   }

--- a/scripts/smoke-package-exports.mjs
+++ b/scripts/smoke-package-exports.mjs
@@ -12,6 +12,7 @@ const checks = [
       'GEORDI_CORE_PROFILE',
       'GEORDI_KNOWN_FEATURES',
       'GEORDI_NUMERIC_PROFILE',
+      'GEORDI_STRICT_TEXT_FEATURES',
       'isGeordiFeatureRequirement',
       'isGeordiScene',
       'isRectNode',

--- a/scripts/smoke-package-exports.mjs
+++ b/scripts/smoke-package-exports.mjs
@@ -10,6 +10,7 @@ const checks = [
     exports: [
       'GEORDI_BASELINE_FEATURES',
       'GEORDI_CORE_PROFILE',
+      'GEORDI_KNOWN_FEATURES',
       'GEORDI_NUMERIC_PROFILE',
       'isGeordiFeatureRequirement',
       'isGeordiScene',


### PR DESCRIPTION
## Summary

Executes the next 10-slice hit list from the design pack.

- Refreshes operating docs for the post-design-pack baseline.
- Adds the strict text/font profile as a P0 backlog/design-law target.
- Splits core known feature requirements from compiler-emitted baseline requirements.
- Adds strict text feature vocabulary while keeping baseline output on `text.raw-runtime-shaping`.
- Renames the runtime profile field to `supportedFeatureRequirements`.
- Adds runtime coverage for supported feature subsets and known-but-unsupported strict text requirements.
- Locks compiler IR and receipt tests to `GEORDI_BASELINE_FEATURES` even as the known feature registry grows.
- Adds Group-only type-emission coverage.
- Gates the generated-type `tsc` subprocess behind CI or `TSC_GATE=1` while resolving TypeScript through the package entrypoint.
- Updates status, backlog, and changelog for the completed hit-list work.

Closes #5.
Closes #6.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (191 tests)
- `pnpm test:docs`
- `pnpm test:package-names`
- `pnpm test:repo-sludge`
- `pnpm test:placeholders`
- `pnpm test:exports`
- `git diff --check`
- `TSC_GATE=1 pnpm --filter @flyingrobots/geordi-compiler-core test`

## Notes

This does not implement strict text rendering. It only adds the known feature vocabulary and keeps runtime-webgl failing loudly until strict text support actually exists.