### PR TITLE
Fix render fixture review debt

### DIFF
--- a/BEARING.md
+++ b/BEARING.md
@@ -69,9 +69,10 @@ Still true:
 
 - Multi-step geometry, vector, matrix, transform, and animation operation-order rules still need to
   be specified as those features are introduced.
-- There is no browser demo scaffold yet, and there is no Rust workspace or native runtime scaffold
-  yet. The current browser runtime API can render `geordi-ir/1` to a browser-created canvas, but it
-  is still a Canvas 2D proof of concept inside the `runtime-webgl` package.
+- The browser demo scaffold now renders the shared fixture into a browser canvas, and the Rust
+  workspace now includes a native renderer plus smoke harness for the same canonical artifact.
+  The current proof remains rectangle-only until stricter text, geometry, and transform profiles
+  are specified.
 
 ## Render-Everywhere Target
 

--- a/docs/design/2026-05-native-rust-render-harness.md
+++ b/docs/design/2026-05-native-rust-render-harness.md
@@ -147,7 +147,7 @@ specific. Do not collapse everything into a generic string error.
 The native example binary should accept a fixture path:
 
 ```bash
-cargo run -p geordi-native-render-everywhere -- fixtures/render-everywhere/hello-panel/fixture.json
+cargo run -p native-render-everywhere -- fixtures/render-everywhere/hello-panel/fixture.json
 ```
 
 Flow:
@@ -180,7 +180,7 @@ CI should not require an interactive desktop window.
 Add a mode such as:
 
 ```bash
-cargo run -p geordi-native-render-everywhere -- --smoke fixtures/render-everywhere/hello-panel/fixture.json
+cargo run -p native-render-everywhere -- --smoke fixtures/render-everywhere/hello-panel/fixture.json
 ```
 
 Smoke mode should:
@@ -241,7 +241,7 @@ Once the native renderer exists, CI should run:
 cargo fmt --check
 cargo test
 cargo clippy --workspace --all-targets -- -D warnings
-cargo run -p geordi-native-render-everywhere -- --smoke fixtures/render-everywhere/hello-panel/fixture.json
+cargo run -p native-render-everywhere -- --smoke fixtures/render-everywhere/hello-panel/fixture.json
 ```
 
 ## Acceptance Criteria

--- a/packages/render-fixture/src/index.test.ts
+++ b/packages/render-fixture/src/index.test.ts
@@ -234,7 +234,7 @@ describe('render fixture manifest validation', () => {
       source: {
         compiler: '@flyingrobots/geordi-gpvue',
         kind: 'gpvue-draft',
-        path: '../source.gpvue',
+        path: 'file://source.gpvue',
       },
     };
 
@@ -245,6 +245,31 @@ describe('render fixture manifest validation', () => {
       '$.source.path',
       '$.source.compiler',
     ]);
+  });
+
+  it('rejects nonlocal source path forms', () => {
+    const invalidPaths = [
+      '../source.gpvue',
+      '/tmp/source.gpvue',
+      'C:\\tmp\\source.gpvue',
+      '\\\\server\\share\\source.gpvue',
+      'https://example.test/source.gpvue',
+    ];
+
+    for (const sourcePath of invalidPaths) {
+      const invalid: JsonValue = {
+        ...makeManifest(),
+        source: {
+          kind: RENDER_FIXTURE_SOURCE_KIND_GPVUE_DRAFT,
+          path: sourcePath,
+        },
+      };
+
+      const result = validateRenderFixtureManifest(invalid);
+
+      expect(result.ok).toBe(false);
+      expect(result.issues.map((issue) => issue.path)).toEqual(['$.source.path']);
+    }
   });
 
   it('rejects invalid probes', () => {

--- a/packages/render-fixture/src/index.ts
+++ b/packages/render-fixture/src/index.ts
@@ -19,6 +19,7 @@ export const RENDER_FIXTURE_SOURCE_KIND_NONE = 'none' as const;
 export const RENDER_FIXTURE_SOURCE_KIND_GPVUE_DRAFT = 'gpvue-draft' as const;
 export const RENDER_FIXTURE_SOURCE_KIND_GPVUE = 'gpvue' as const;
 const WINDOWS_DRIVE_PREFIX_PATTERN = /^[A-Za-z]:/u;
+const URL_SCHEME_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:\/\//u;
 
 export interface RenderFixtureManifestIssue extends JsonObject {
   readonly path: string;
@@ -599,7 +600,8 @@ function isFixtureLocalRelativePath(value: string): boolean {
     !value.startsWith('/') &&
     !value.includes('\\') &&
     !value.includes('..') &&
-    !WINDOWS_DRIVE_PREFIX_PATTERN.test(value)
+    !WINDOWS_DRIVE_PREFIX_PATTERN.test(value) &&
+    !URL_SCHEME_PATTERN.test(value)
   );
 }
 

--- a/scripts/render-everywhere-gpvue-smoke.ts
+++ b/scripts/render-everywhere-gpvue-smoke.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join, resolve, sep } from 'node:path';
 
 import { stringifyCanonicalJson } from '@flyingrobots/geordi-core';
 import { compileGpvueSource } from '@flyingrobots/geordi-gpvue';
@@ -39,6 +39,16 @@ class RenderEverywhereSourceKindError extends Error {
   }
 }
 
+class RenderEverywhereFixturePathError extends Error {
+  public readonly fixturePath: string;
+
+  constructor(fixturePath: string) {
+    super('Render-everywhere fixture path escapes the temporary directory');
+    this.name = new.target.name;
+    this.fixturePath = fixturePath;
+  }
+}
+
 async function main(): Promise<void> {
   const manifest = parseRenderFixtureManifest(await readFile(MANIFEST_PATH, 'utf8'));
   const source = await readFile(SOURCE_PATH, 'utf8');
@@ -64,7 +74,7 @@ async function main(): Promise<void> {
       `${stringifyCanonicalJson(manifest, { space: 2 })}\n`,
       'utf8',
     );
-    await writeFile(join(tempDir, sourceArtifact), source, 'utf8');
+    await writeFixtureLocalFile(tempDir, sourceArtifact, source);
     await writeFile(join(tempDir, SCENE_ARTIFACT), compiled.artifacts.ir.content, 'utf8');
     await writeFile(join(tempDir, RECEIPT_ARTIFACT), compiled.artifacts.receipt.content, 'utf8');
     await writeFile(join(tempDir, SOURCE_MAP_ARTIFACT), compiled.artifacts.sourceMap.content, 'utf8');
@@ -77,6 +87,21 @@ async function main(): Promise<void> {
   } finally {
     await rm(tempDir, { force: true, recursive: true });
   }
+}
+
+async function writeFixtureLocalFile(
+  tempDir: string,
+  fixturePath: string,
+  content: string,
+): Promise<void> {
+  const tempRoot = resolve(tempDir);
+  const targetPath = resolve(tempRoot, fixturePath);
+  if (targetPath === tempRoot || !targetPath.startsWith(`${tempRoot}${sep}`)) {
+    throw new RenderEverywhereFixturePathError(fixturePath);
+  }
+
+  await mkdir(dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, content, 'utf8');
 }
 
 function run(command: string, args: readonly string[], env: NodeJS.ProcessEnv): void {


### PR DESCRIPTION
## Summary
- update render-everywhere bearing/docs now that browser and native scaffolds exist
- reject scheme-based fixture paths in render fixture validation
- keep GPVue smoke source materialization inside its temp fixture directory

## Verification
- pnpm --filter @flyingrobots/geordi-render-fixture typecheck
- pnpm --filter @flyingrobots/geordi-render-fixture lint
- pnpm --filter @flyingrobots/geordi-render-fixture test
- pnpm lint:root
- pnpm test:docs
- pnpm test:render-everywhere:gpvue
- git diff --check